### PR TITLE
Enabling upsert option for Cosmos sink

### DIFF
--- a/Extensions/Cosmos/Cosmos.DataTransfer.CosmosExtension/CosmosSinkSettings.cs
+++ b/Extensions/Cosmos/Cosmos.DataTransfer.CosmosExtension/CosmosSinkSettings.cs
@@ -21,6 +21,6 @@ namespace Cosmos.DataTransfer.CosmosExtension
         public int InitialRetryDurationMs { get; set; } = 200;
         public int? CreatedContainerMaxThroughput { get; set; }
         public bool UseAutoscaleForCreatedContainer { get; set; } = true;
-        public bool InsertStreams { get; set; } = true;
+        public DataWriteMode WriteMode { get; set; } = DataWriteMode.InsertStream;
     }
 }

--- a/Extensions/Cosmos/Cosmos.DataTransfer.CosmosExtension/DataWriteMode.cs
+++ b/Extensions/Cosmos/Cosmos.DataTransfer.CosmosExtension/DataWriteMode.cs
@@ -1,0 +1,10 @@
+﻿namespace Cosmos.DataTransfer.CosmosExtension
+{
+    public enum DataWriteMode
+    {
+        InsertStream,
+        Insert,
+        UpsertStream,
+        Upsert,
+    }
+}

--- a/Extensions/Cosmos/README.md
+++ b/Extensions/Cosmos/README.md
@@ -26,7 +26,7 @@ Source supports an optional `IncludeMetadataFields` parameter (`false` by defaul
 }
 ```
 
-Sink requires an additional `PartitionKeyPath` parameter which is used when creating the container if it does not exist. It also supports an optional `RecreateContainer` parameter (`false` by default) to delete and then recreate the container to ensure only newly imported data is present. The optional `BatchSize` parameter (100 by default) sets the number of items to accumulate before inserting.
+Sink requires an additional `PartitionKeyPath` parameter which is used when creating the container if it does not exist. It also supports an optional `RecreateContainer` parameter (`false` by default) to delete and then recreate the container to ensure only newly imported data is present. The optional `BatchSize` parameter (100 by default) sets the number of items to accumulate before inserting. The optional WriteMode parameter specifies the type of data write to use: InsertStream, Insert, UpsertStream, or Upsert.
 
 ### Sink
 
@@ -37,6 +37,7 @@ Sink requires an additional `PartitionKeyPath` parameter which is used when crea
     "Container":"myContainer",
     "PartitionKeyPath":"/id",
     "RecreateContainer": false,
-    "BatchSize": 100
+    "BatchSize": 100,
+    "WriteMode": "InsertStream"
 }
 ```

--- a/Extensions/Json/Cosmos.DataTransfer.JsonExtension.UnitTests/JsonRoundTripTests.cs
+++ b/Extensions/Json/Cosmos.DataTransfer.JsonExtension.UnitTests/JsonRoundTripTests.cs
@@ -63,7 +63,7 @@ namespace Cosmos.DataTransfer.JsonExtension.UnitTests
             var input = new JsonDataSourceExtension();
             var output = new JsonDataSinkExtension();
 
-            const string urlIn = "https://raw.githubusercontent.com/AzureCosmosDB/data-migration-desktop-tool/feature/cosmos-configuration/Extensions/Json/Microsoft.DataTransfer.JsonExtension.UnitTests/Data/ArraysTypesNesting.json";
+            const string urlIn = "https://raw.githubusercontent.com/AzureCosmosDB/data-migration-desktop-tool/main/Extensions/Json/Cosmos.DataTransfer.JsonExtension.UnitTests/Data/ArraysTypesNesting.json";
             const string compareFile = "Data/ArraysTypesNesting.json";
             const string fileOut = $"{nameof(WriteAsync_fromReadAsync_ProducesIdenticalFile)}_out.json";
             


### PR DESCRIPTION
Changing Cosmos sink to allow 4 different modes set by a WriteMode config property:

- Insert
- InsertStream
- Upsert
- UpsertStream