### PR TITLE
JSON Source async Streams

### DIFF
--- a/Extensions/Json/Cosmos.DataTransfer.JsonExtension.UnitTests/JsonSinkTests.cs
+++ b/Extensions/Json/Cosmos.DataTransfer.JsonExtension.UnitTests/JsonSinkTests.cs
@@ -44,11 +44,88 @@ namespace Cosmos.DataTransfer.JsonExtension.UnitTests
             Assert.IsTrue(outputData.Any(o => o.Id == 2 && o.Name == "Two"));
             Assert.IsTrue(outputData.Any(o => o.Id == 3 && o.Name == "Three"));
         }
+
+        [TestMethod]
+        public async Task WriteAsync_WithSourceDates_PreservesDateFormats()
+        {
+            var sink = new JsonDataSinkExtension();
+
+            var now = DateTime.UtcNow;
+            var randomTime = DateTime.UtcNow.AddMinutes(Random.Shared.NextDouble() * 10000);
+            var data = new List<DictionaryDataItem>
+            {
+                new(new Dictionary<string, object?>
+                {
+                    { "Id", 1 },
+                    { "Created", now },
+                }),
+                new(new Dictionary<string, object?>
+                {
+                    { "Id", 2 },
+                    { "Created", DateTime.UnixEpoch },
+                }),
+                new(new Dictionary<string, object?>
+                {
+                    { "Id", 3 },
+                    { "Created", randomTime },
+                }),
+            };
+            string outputFile = $"{now:yy-MM-dd}_DateOutput.json";
+            var config = TestHelpers.CreateConfig(new Dictionary<string, string>
+            {
+                { "FilePath", outputFile }
+            });
+
+            await sink.WriteAsync(data.ToAsyncEnumerable(), config, new JsonDataSourceExtension(), NullLogger.Instance);
+
+            string json = await File.ReadAllTextAsync(outputFile);
+            var outputData = JsonConvert.DeserializeObject<List<TestDataObject>>(json);
+
+            Assert.IsTrue(outputData.Any(o => o.Id == 1 && o.Created == now));
+            Assert.IsTrue(outputData.Any(o => o.Id == 2 && o.Created == DateTime.UnixEpoch));
+            Assert.IsTrue(outputData.Any(o => o.Id == 3 && o.Created == randomTime));
+        }
+
+
+        [TestMethod]
+        public async Task WriteAsync_WithDateArray_PreservesDateFormats()
+        {
+            var sink = new JsonDataSinkExtension();
+
+            var now = DateTime.UtcNow;
+            var randomTime = DateTime.UtcNow.AddMinutes(Random.Shared.NextDouble() * 10000);
+            var data = new List<DictionaryDataItem>
+            {
+                new(new Dictionary<string, object?>
+                {
+                    { "Id", 1 },
+                    { "Dates", new[] { now, randomTime, DateTime.UnixEpoch } },
+                })
+            };
+
+            string outputFile = $"{now:yy-MM-dd}_DateArrayOutput.json";
+            var config = TestHelpers.CreateConfig(new Dictionary<string, string>
+            {
+                { "FilePath", outputFile }
+            });
+
+            await sink.WriteAsync(data.ToAsyncEnumerable(), config, new JsonDataSourceExtension(), NullLogger.Instance);
+
+            string json = await File.ReadAllTextAsync(outputFile);
+            var outputData = JsonConvert.DeserializeObject<List<TestDataObject>>(json);
+
+            Assert.AreEqual(now, outputData.Single().Dates.ElementAt(0));
+            Assert.AreEqual(randomTime, outputData.Single().Dates.ElementAt(1));
+            Assert.AreEqual(DateTime.UnixEpoch, outputData.Single().Dates.ElementAt(2));
+        }
+
     }
 
     public class TestDataObject
     {
         public int Id { get; set; }
         public string? Name { get; set; }
+        public DateTime? Created { get; set; }
+        public List<DateTime>? Dates { get; set; }
     }
 }

--- a/Extensions/Json/Cosmos.DataTransfer.JsonExtension/Cosmos.DataTransfer.JsonExtension.csproj
+++ b/Extensions/Json/Cosmos.DataTransfer.JsonExtension/Cosmos.DataTransfer.JsonExtension.csproj
@@ -10,6 +10,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
 		<PackageReference Include="System.ComponentModel.Composition" Version="6.0.0" />
+		<PackageReference Include="System.Linq.Async" Version="6.0.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Interfaces/Cosmos.DataTransfer.Interfaces/DataItemJsonConverter.cs
+++ b/Interfaces/Cosmos.DataTransfer.Interfaces/DataItemJsonConverter.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System.Collections;
+using System.Text;
 using System.Text.Json;
 
 namespace Cosmos.DataTransfer.Interfaces;
@@ -52,7 +53,7 @@ public static class DataItemJsonConverter
             {
                 WriteDataItem(writer, child, includeNullFields, fieldName);
             }
-            else if (fieldValue is IEnumerable<object> children)
+            else if (fieldValue is not string && fieldValue is IEnumerable children)
             {
                 writer.WriteStartArray(fieldName);
                 foreach (object arrayItem in children)
@@ -69,6 +70,10 @@ public static class DataItemJsonConverter
                     {
                         writer.WriteBooleanValue(boolean);
                     }
+                    else if (arrayItem is DateTime date)
+                    {
+                        writer.WriteStringValue(date.ToString("O"));
+                    }
                     else
                     {
                         writer.WriteStringValue(arrayItem.ToString());
@@ -83,6 +88,10 @@ public static class DataItemJsonConverter
             else if (fieldValue is bool boolean)
             {
                 writer.WriteBoolean(fieldName, boolean);
+            }
+            else if (fieldValue is DateTime date)
+            {
+                writer.WriteString(fieldName, date.ToString("O"));
             }
             else
             {

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The Azure Cosmos DB Desktop Data Migration Tool is an open-source project contai
 
 ## Quick Installation
 
-To use the tool, download the latest zip file for your platform (win-x64, mac-x64, or linux-x64) from [Releases](releases) and extract all files to your desired install location. To begin a data transfer operation, first populate the `migrationsettings.json` file with appropriate settings for your data source and sink (see [detailed instructions](#using-the-command-line) below), and then run the application from a command line: `dmt.exe` on Windows or `dmt` on other platforms.
+To use the tool, download the latest zip file for your platform (win-x64, mac-x64, or linux-x64) from [Releases](https://github.com/AzureCosmosDB/data-migration-desktop-tool/releases) and extract all files to your desired install location. To begin a data transfer operation, first populate the `migrationsettings.json` file with appropriate settings for your data source and sink (see [detailed instructions](#using-the-command-line) below), and then run the application from a command line: `dmt.exe` on Windows or `dmt` on other platforms.
 
 ## Extension documentation
 


### PR DESCRIPTION
Updates JSON Source extension to read data asynchronously from streams instead of preloading complete files to reduce memory usage and enable large file transfers as mentioned in Issue #35

Updates JSON Sink to write date values using ISO-8601 round-trip string format to fix Issue #36 

Fixes link in Quick Install doc as mentioned in #43  