### PR TITLE
Adding prototype implementation of split storage+formatter extension

### DIFF
--- a/Core/Cosmos.DataTransfer.Core/Properties/launchSettings.json
+++ b/Core/Cosmos.DataTransfer.Core/Properties/launchSettings.json
@@ -18,11 +18,11 @@
     },
     "JSON->SqlServer": {
       "commandName": "Project",
-      "commandLineArgs": "run --source json --sink sqlServer --SourceSettings:FilePath=c:\\temp\\test-json-sql-in.json --SettingsPath=c:\\temp\\Json-SqlSettings.json"
+      "commandLineArgs": "run --source json --sink sqlServer --SourceSettings:FilePath=c:\\temp\\test-json-sql-in.json --settings=c:\\temp\\Json-SqlSettings.json"
     },
     "JSON URI->Cosmos": {
       "commandName": "Project",
-      "commandLineArgs": "--source json --sink cosmos-nosql --SourceSettings:FilePath=https://raw.githubusercontent.com/AzureCosmosDB/data-migration-desktop-tool/feature/cosmos-configuration/Extensions/Json/.JsonExtension.UnitTests/Data/ArraysTypesNesting.json --SettingsPath=c:\\temp\\CosmosSinkSettings.json"
+      "commandLineArgs": "--source json-file --sink cosmos-nosql --SourceSettings:FilePath=https://raw.githubusercontent.com/AzureCosmosDB/data-migration-desktop-tool/main/Extensions/Json/Cosmos.DataTransfer.JsonExtension.UnitTests/Data/ArraysTypesNesting.json --settings=c:\\temp\\CosmosSinkSettings.json"
     }
   }
 }

--- a/Cosmos.DataTransfer.Common/CompositeSinkExtension.cs
+++ b/Cosmos.DataTransfer.Common/CompositeSinkExtension.cs
@@ -1,0 +1,20 @@
+﻿using Cosmos.DataTransfer.Interfaces;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Cosmos.DataTransfer.Common;
+
+public abstract class CompositeSinkExtension<TSink, TFormatter> : IDataSinkExtension
+    where TSink : class, IComposableDataSink, new()
+    where TFormatter : class, IFormattedDataWriter, new()
+{
+    public abstract string DisplayName { get; }
+
+    public async Task WriteAsync(IAsyncEnumerable<IDataItem> dataItems, IConfiguration config, IDataSourceExtension dataSource, ILogger logger, CancellationToken cancellationToken = default)
+    {
+        var sink = new TSink();
+        var formatter = new TFormatter();
+
+        await sink.WriteToTargetAsync(formatter, dataItems, config, dataSource, logger, cancellationToken);
+    }
+}

--- a/Cosmos.DataTransfer.Common/CompositeSourceExtension.cs
+++ b/Cosmos.DataTransfer.Common/CompositeSourceExtension.cs
@@ -1,0 +1,21 @@
+﻿using Cosmos.DataTransfer.Interfaces;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Cosmos.DataTransfer.Common
+{
+    public abstract class CompositeSourceExtension<TSource, TFormatter> : IDataSourceExtension
+        where TSource : class, IComposableDataSource, new()
+        where TFormatter : class, IFormattedDataReader, new()
+    {
+        public abstract string DisplayName { get; }
+
+        public IAsyncEnumerable<IDataItem> ReadAsync(IConfiguration config, ILogger logger, CancellationToken cancellationToken = default)
+        {
+            var source = new TSource();
+            var formatter = new TFormatter();
+
+            return formatter.ParseDataAsync(source, config, logger, cancellationToken);
+        }
+    }
+}

--- a/Cosmos.DataTransfer.Common/Cosmos.DataTransfer.Common.csproj
+++ b/Cosmos.DataTransfer.Common/Cosmos.DataTransfer.Common.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Interfaces\Cosmos.DataTransfer.Interfaces\Cosmos.DataTransfer.Interfaces.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Cosmos.DataTransfer.Common/FileDataSink.cs
+++ b/Cosmos.DataTransfer.Common/FileDataSink.cs
@@ -1,0 +1,19 @@
+﻿using Cosmos.DataTransfer.Interfaces;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Cosmos.DataTransfer.Common;
+
+public class FileDataSink : IComposableDataSink
+{
+    public async Task WriteToTargetAsync(IFormattedDataWriter dataWriter, IAsyncEnumerable<IDataItem> dataItems, IConfiguration config, IDataSourceExtension dataSource, ILogger logger, CancellationToken cancellationToken = default)
+    {
+        var settings = config.Get<FileSinkSettings>();
+        settings.Validate();
+        if (settings.FilePath != null)
+        {
+            await using var writer = File.Create(settings.FilePath);
+            await dataWriter.FormatDataAsync(dataItems, writer, config, logger, cancellationToken);
+        }
+    }
+}

--- a/Cosmos.DataTransfer.Common/FileDataSource.cs
+++ b/Cosmos.DataTransfer.Common/FileDataSource.cs
@@ -1,0 +1,56 @@
+﻿using Cosmos.DataTransfer.Interfaces;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Cosmos.DataTransfer.Common;
+
+public class FileDataSource : IComposableDataSource
+{
+    public async IAsyncEnumerable<Stream?> ReadSourceAsync(IConfiguration config, ILogger logger, CancellationToken cancellationToken = default)
+    {
+        var settings = config.Get<FileSourceSettings>();
+        settings.Validate();
+        if (settings.FilePath != null)
+        {
+
+            if (File.Exists(settings.FilePath))
+            {
+                logger.LogInformation("Reading file '{FilePath}'", settings.FilePath);
+                yield return File.OpenRead(settings.FilePath);
+            }
+            else if (Directory.Exists(settings.FilePath))
+            {
+                string[] files = Directory.GetFiles(settings.FilePath, "*.json", SearchOption.AllDirectories);
+                logger.LogInformation("Reading {FileCount} files from '{Folder}'", files.Length, settings.FilePath);
+                foreach (string filePath in files.OrderBy(f => f))
+                {
+                    logger.LogInformation("Reading file '{FilePath}'", filePath);
+                    yield return File.OpenRead(filePath);
+                }
+            }
+            else if (Uri.IsWellFormedUriString(settings.FilePath, UriKind.RelativeOrAbsolute))
+            {
+                logger.LogInformation("Reading from URI '{FilePath}'", settings.FilePath);
+
+                HttpClient client = new HttpClient();
+                var response = await client.GetAsync(settings.FilePath, cancellationToken);
+                if (!response.IsSuccessStatusCode)
+                {
+                    logger.LogError("Failed to read {FilePath}. Response was: {ResponseCode} {ResponseMessage}", settings.FilePath, response.StatusCode, response.ReasonPhrase);
+                    yield break;
+                }
+
+                var json = await response.Content.ReadAsStreamAsync(cancellationToken);
+
+                yield return json;
+            }
+            else
+            {
+                logger.LogWarning("No content was found at configured path '{FilePath}'", settings.FilePath);
+                yield break;
+            }
+
+            logger.LogInformation("Completed reading '{FilePath}'", settings.FilePath);
+        }
+    }
+}

--- a/Cosmos.DataTransfer.Common/FileSinkSettings.cs
+++ b/Cosmos.DataTransfer.Common/FileSinkSettings.cs
@@ -1,0 +1,10 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Cosmos.DataTransfer.Interfaces;
+
+namespace Cosmos.DataTransfer.Common;
+
+public class FileSinkSettings : IDataExtensionSettings
+{
+    [Required]
+    public string? FilePath { get; set; }
+}

--- a/Cosmos.DataTransfer.Common/FileSourceSettings.cs
+++ b/Cosmos.DataTransfer.Common/FileSourceSettings.cs
@@ -1,0 +1,10 @@
+﻿using System.ComponentModel.DataAnnotations;
+using Cosmos.DataTransfer.Interfaces;
+
+namespace Cosmos.DataTransfer.Common;
+
+public class FileSourceSettings : IDataExtensionSettings
+{
+    [Required]
+    public string? FilePath { get; set; }
+}

--- a/CosmosDbDataMigrationTool.sln
+++ b/CosmosDbDataMigrationTool.sln
@@ -54,6 +54,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Cosmos.DataTransfer.SqlServ
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Cosmos.DataTransfer.SqlServerExtension.UnitTests", "Extensions\SqlServer\Cosmos.DataTransfer.SqlServerExtension.UnitTests\Cosmos.DataTransfer.SqlServerExtension.UnitTests.csproj", "{3E4C4ABF-D8C2-4997-A719-E756483C8D63}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cosmos.DataTransfer.Common", "Cosmos.DataTransfer.Common\Cosmos.DataTransfer.Common.csproj", "{0FAD9D89-2E41-4D65-8440-5C01885D9292}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -108,6 +110,10 @@ Global
 		{3E4C4ABF-D8C2-4997-A719-E756483C8D63}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3E4C4ABF-D8C2-4997-A719-E756483C8D63}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3E4C4ABF-D8C2-4997-A719-E756483C8D63}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0FAD9D89-2E41-4D65-8440-5C01885D9292}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0FAD9D89-2E41-4D65-8440-5C01885D9292}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0FAD9D89-2E41-4D65-8440-5C01885D9292}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0FAD9D89-2E41-4D65-8440-5C01885D9292}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Extensions/Json/Cosmos.DataTransfer.JsonExtension.UnitTests/JsonFileRoundTripTests.cs
+++ b/Extensions/Json/Cosmos.DataTransfer.JsonExtension.UnitTests/JsonFileRoundTripTests.cs
@@ -4,13 +4,13 @@ using Newtonsoft.Json.Linq;
 namespace Cosmos.DataTransfer.JsonExtension.UnitTests
 {
     [TestClass]
-    public class JsonRoundTripTests
+    public class JsonFileRoundTripTests
     {
         [TestMethod]
         public async Task WriteAsync_fromReadAsync_ProducesIdenticalFile()
         {
-            var input = new JsonDataSourceExtension();
-            var output = new JsonDataSinkExtension();
+            var input = new JsonFileSource();
+            var output = new JsonFileSink();
 
             const string fileIn = "Data/ArraysTypesNesting.json";
             const string fileOut = $"{nameof(WriteAsync_fromReadAsync_ProducesIdenticalFile)}_out.json";
@@ -34,8 +34,8 @@ namespace Cosmos.DataTransfer.JsonExtension.UnitTests
         [TestMethod]
         public async Task WriteAsync_fromFolderReadAsync_ProducesExpectedCombinedFile()
         {
-            var input = new JsonDataSourceExtension();
-            var output = new JsonDataSinkExtension();
+            var input = new JsonFileSource();
+            var output = new JsonFileSink();
 
             const string fileIn = "Data/SingleObjects";
             const string fileCompare = "Data/SimpleIdName.json";
@@ -60,8 +60,8 @@ namespace Cosmos.DataTransfer.JsonExtension.UnitTests
         [TestMethod]
         public async Task WriteAsync_fromReadUriAsync_ProducesIdenticalFile()
         {
-            var input = new JsonDataSourceExtension();
-            var output = new JsonDataSinkExtension();
+            var input = new JsonFileSource();
+            var output = new JsonFileSink();
 
             const string urlIn = "https://raw.githubusercontent.com/AzureCosmosDB/data-migration-desktop-tool/main/Extensions/Json/Cosmos.DataTransfer.JsonExtension.UnitTests/Data/ArraysTypesNesting.json";
             const string compareFile = "Data/ArraysTypesNesting.json";

--- a/Extensions/Json/Cosmos.DataTransfer.JsonExtension.UnitTests/JsonFileSinkTests.cs
+++ b/Extensions/Json/Cosmos.DataTransfer.JsonExtension.UnitTests/JsonFileSinkTests.cs
@@ -1,0 +1,48 @@
+using Cosmos.DataTransfer.Interfaces;
+using Microsoft.Extensions.Logging.Abstractions;
+using Newtonsoft.Json;
+
+namespace Cosmos.DataTransfer.JsonExtension.UnitTests
+{
+    [TestClass]
+    public class JsonFileSinkTests
+    {
+        [TestMethod]
+        public async Task WriteAsync_WithFlatObjects_WritesToValidFile()
+        {
+            var sink = new JsonFileSink();
+
+            var data = new List<DictionaryDataItem>
+            {
+                new(new Dictionary<string, object?>
+                {
+                    { "Id", 1 },
+                    { "Name", "One" },
+                }),
+                new(new Dictionary<string, object?>
+                {
+                    { "Id", 2 },
+                    { "Name", "Two" },
+                }),
+                new(new Dictionary<string, object?>
+                {
+                    { "Id", 3 },
+                    { "Name", "Three" },
+                }),
+            };
+            string outputFile = $"{DateTime.Now:yy-MM-dd}_FS_Output.json";
+            var config = TestHelpers.CreateConfig(new Dictionary<string, string>
+            {
+                { "FilePath", outputFile }
+            });
+
+            await sink.WriteAsync(data.ToAsyncEnumerable(), config, new JsonDataSourceExtension(), NullLogger.Instance);
+
+            var outputData = JsonConvert.DeserializeObject<List<TestDataObject>>(await File.ReadAllTextAsync(outputFile));
+
+            Assert.IsTrue(outputData.Any(o => o.Id == 1 && o.Name == "One"));
+            Assert.IsTrue(outputData.Any(o => o.Id == 2 && o.Name == "Two"));
+            Assert.IsTrue(outputData.Any(o => o.Id == 3 && o.Name == "Three"));
+        }
+    }
+}

--- a/Extensions/Json/Cosmos.DataTransfer.JsonExtension.UnitTests/JsonSinkTests.cs
+++ b/Extensions/Json/Cosmos.DataTransfer.JsonExtension.UnitTests/JsonSinkTests.cs
@@ -114,18 +114,10 @@ namespace Cosmos.DataTransfer.JsonExtension.UnitTests
             string json = await File.ReadAllTextAsync(outputFile);
             var outputData = JsonConvert.DeserializeObject<List<TestDataObject>>(json);
 
-            Assert.AreEqual(now, outputData.Single().Dates.ElementAt(0));
-            Assert.AreEqual(randomTime, outputData.Single().Dates.ElementAt(1));
-            Assert.AreEqual(DateTime.UnixEpoch, outputData.Single().Dates.ElementAt(2));
+            Assert.AreEqual(now, outputData?.Single().Dates?.ElementAt(0));
+            Assert.AreEqual(randomTime, outputData?.Single().Dates?.ElementAt(1));
+            Assert.AreEqual(DateTime.UnixEpoch, outputData?.Single().Dates?.ElementAt(2));
         }
 
-    }
-
-    public class TestDataObject
-    {
-        public int Id { get; set; }
-        public string? Name { get; set; }
-        public DateTime? Created { get; set; }
-        public List<DateTime>? Dates { get; set; }
     }
 }

--- a/Extensions/Json/Cosmos.DataTransfer.JsonExtension.UnitTests/TestDataObject.cs
+++ b/Extensions/Json/Cosmos.DataTransfer.JsonExtension.UnitTests/TestDataObject.cs
@@ -1,0 +1,10 @@
+namespace Cosmos.DataTransfer.JsonExtension.UnitTests
+{
+    public class TestDataObject
+    {
+        public int Id { get; set; }
+        public string? Name { get; set; }
+        public DateTime? Created { get; set; }
+        public List<DateTime>? Dates { get; set; }
+    }
+}

--- a/Extensions/Json/Cosmos.DataTransfer.JsonExtension/Cosmos.DataTransfer.JsonExtension.csproj
+++ b/Extensions/Json/Cosmos.DataTransfer.JsonExtension/Cosmos.DataTransfer.JsonExtension.csproj
@@ -14,6 +14,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<ProjectReference Include="..\..\..\Cosmos.DataTransfer.Common\Cosmos.DataTransfer.Common.csproj" />
 		<ProjectReference Include="..\..\..\Interfaces\Cosmos.DataTransfer.Interfaces\Cosmos.DataTransfer.Interfaces.csproj" />
 	</ItemGroup>
 

--- a/Extensions/Json/Cosmos.DataTransfer.JsonExtension/JsonFileSink.cs
+++ b/Extensions/Json/Cosmos.DataTransfer.JsonExtension/JsonFileSink.cs
@@ -1,0 +1,12 @@
+﻿using Cosmos.DataTransfer.Common;
+using Cosmos.DataTransfer.Interfaces;
+using System.ComponentModel.Composition;
+
+namespace Cosmos.DataTransfer.JsonExtension;
+
+[Export(typeof(IDataSinkExtension))]
+public class JsonFileSink : CompositeSinkExtension<FileDataSink, JsonFormatWriter>
+{
+    public override string DisplayName => "JSON-File(beta)";
+}
+

--- a/Extensions/Json/Cosmos.DataTransfer.JsonExtension/JsonFileSource.cs
+++ b/Extensions/Json/Cosmos.DataTransfer.JsonExtension/JsonFileSource.cs
@@ -1,0 +1,11 @@
+﻿using Cosmos.DataTransfer.Common;
+using Cosmos.DataTransfer.Interfaces;
+using System.ComponentModel.Composition;
+
+namespace Cosmos.DataTransfer.JsonExtension;
+
+[Export(typeof(IDataSourceExtension))]
+public class JsonFileSource : CompositeSourceExtension<FileDataSource, JsonFormatReader>
+{
+    public override string DisplayName => "JSON-File(beta)";
+}

--- a/Extensions/Json/Cosmos.DataTransfer.JsonExtension/JsonFormatReader.cs
+++ b/Extensions/Json/Cosmos.DataTransfer.JsonExtension/JsonFormatReader.cs
@@ -1,0 +1,99 @@
+﻿using System.Runtime.CompilerServices;
+using Cosmos.DataTransfer.Interfaces;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using System.Text.Json;
+
+namespace Cosmos.DataTransfer.JsonExtension;
+
+public class JsonFormatReader : IFormattedDataReader
+{
+    public async IAsyncEnumerable<IDataItem> ParseDataAsync(IComposableDataSource sourceExtension, IConfiguration config, ILogger logger, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        var streams = sourceExtension.ReadSourceAsync(config, logger, cancellationToken);
+
+        await foreach (var stream in streams.WithCancellation(cancellationToken))
+        {
+            if (stream != null)
+            {
+                var list = ReadJsonItemsAsync(stream, logger, cancellationToken);
+                if (list != null)
+                {
+                    await foreach (var listItem in list.WithCancellation(cancellationToken))
+                    {
+                        if (listItem != null)
+                        {
+                            yield return new JsonDictionaryDataItem(listItem);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private static IAsyncEnumerable<Dictionary<string, object?>?>? ReadJsonItemsAsync(Stream jsonStream, ILogger logger, CancellationToken cancellationToken)
+    {
+        if (jsonStream is { CanSeek: true, Length: < 1485760L })
+        {
+            // test for single item in JSON
+            var singleItemList = ReadSingleItemAsync(jsonStream, logger);
+            if (singleItemList != null)
+            {
+                return singleItemList.ToAsyncEnumerable();
+            }
+        }
+
+        try
+        {
+            jsonStream.Seek(0, SeekOrigin.Begin);
+            return JsonSerializer.DeserializeAsyncEnumerable<Dictionary<string, object?>>(jsonStream, cancellationToken: cancellationToken);
+        }
+        catch (Exception)
+        {
+            // list failed
+        }
+
+        return null;
+    }
+
+    private static IEnumerable<Dictionary<string, object?>?>? ReadSingleItemAsync(Stream stream, ILogger logger)
+    {
+        Dictionary<string, object?>? item;
+        try
+        {
+            item = JsonSerializer.Deserialize<Dictionary<string, object?>>(stream);
+        }
+        catch (Exception)
+        {
+            // single item failed
+            return null;
+        }
+
+        if (item != null)
+        {
+            return new[] { item };
+        }
+
+        logger.LogWarning("No records read from '{Content}'", ReadTextForLogging(stream, logger));
+
+        return null;
+    }
+
+    private static string ReadTextForLogging(Stream stream, ILogger logger)
+    {
+        string textContent;
+        try
+        {
+            var chars = new char[50];
+            new StreamReader(stream).ReadBlock(chars, 0, chars.Length);
+            textContent = new string(chars);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to read stream");
+            textContent = "<error>";
+        }
+
+        return textContent;
+    }
+}

--- a/Extensions/Json/Cosmos.DataTransfer.JsonExtension/JsonFormatWriter.cs
+++ b/Extensions/Json/Cosmos.DataTransfer.JsonExtension/JsonFormatWriter.cs
@@ -1,0 +1,29 @@
+﻿using Cosmos.DataTransfer.Interfaces;
+using Cosmos.DataTransfer.JsonExtension.Settings;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using System.Text.Json;
+
+namespace Cosmos.DataTransfer.JsonExtension;
+
+public class JsonFormatWriter : IFormattedDataWriter
+{
+    public async Task FormatDataAsync(IAsyncEnumerable<IDataItem> dataItems, Stream target, IConfiguration config, ILogger logger, CancellationToken cancellationToken = default)
+    {
+        var settings = config.Get<JsonFormatWriterSettings>();
+        settings.Validate();
+
+        await using var writer = new Utf8JsonWriter(target, new JsonWriterOptions
+        {
+            Indented = settings.Indented
+        });
+        writer.WriteStartArray();
+
+        await foreach (var item in dataItems.WithCancellation(cancellationToken))
+        {
+            DataItemJsonConverter.WriteDataItem(writer, item, settings.IncludeNullFields);
+        }
+
+        writer.WriteEndArray();
+    }
+}

--- a/Extensions/Json/Cosmos.DataTransfer.JsonExtension/Settings/JsonFormatWriterSettings.cs
+++ b/Extensions/Json/Cosmos.DataTransfer.JsonExtension/Settings/JsonFormatWriterSettings.cs
@@ -1,0 +1,10 @@
+﻿using Cosmos.DataTransfer.Interfaces;
+
+namespace Cosmos.DataTransfer.JsonExtension.Settings
+{
+    public class JsonFormatWriterSettings : IDataExtensionSettings
+    {
+        public bool IncludeNullFields { get; set; }
+        public bool Indented { get; set; }
+    }
+}

--- a/Interfaces/Cosmos.DataTransfer.Interfaces/IComposableDataSink.cs
+++ b/Interfaces/Cosmos.DataTransfer.Interfaces/IComposableDataSink.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Cosmos.DataTransfer.Interfaces;
+
+public interface IComposableDataSink
+{
+    Task WriteToTargetAsync(IFormattedDataWriter dataWriter, IAsyncEnumerable<IDataItem> dataItems, IConfiguration config, IDataSourceExtension dataSource, ILogger logger, CancellationToken cancellationToken = default);
+}

--- a/Interfaces/Cosmos.DataTransfer.Interfaces/IComposableDataSource.cs
+++ b/Interfaces/Cosmos.DataTransfer.Interfaces/IComposableDataSource.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Cosmos.DataTransfer.Interfaces;
+
+public interface IComposableDataSource
+{
+    IAsyncEnumerable<Stream?> ReadSourceAsync(IConfiguration config, ILogger logger, CancellationToken cancellationToken = default);
+}

--- a/Interfaces/Cosmos.DataTransfer.Interfaces/IFormattedDataReader.cs
+++ b/Interfaces/Cosmos.DataTransfer.Interfaces/IFormattedDataReader.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Cosmos.DataTransfer.Interfaces;
+
+public interface IFormattedDataReader
+{
+    IAsyncEnumerable<IDataItem> ParseDataAsync(IComposableDataSource sourceExtension, IConfiguration config, ILogger logger, CancellationToken cancellationToken = default);
+}

--- a/Interfaces/Cosmos.DataTransfer.Interfaces/IFormattedDataWriter.cs
+++ b/Interfaces/Cosmos.DataTransfer.Interfaces/IFormattedDataWriter.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Cosmos.DataTransfer.Interfaces;
+
+public interface IFormattedDataWriter
+{
+    Task FormatDataAsync(IAsyncEnumerable<IDataItem> dataItems, Stream target, IConfiguration config, ILogger logger, CancellationToken cancellationToken = default);
+}


### PR DESCRIPTION
Proposed implementation to address Issue #46 including JSON-File extension for both Source and Sink with behavior to match existing JSON extension.