### PR TITLE
Adding Settings command to generate extension manifest

### DIFF
--- a/Core/Cosmos.DataTransfer.Core.UnitTests/SettingsCommandTests.cs
+++ b/Core/Cosmos.DataTransfer.Core.UnitTests/SettingsCommandTests.cs
@@ -1,0 +1,92 @@
+using Cosmos.DataTransfer.Interfaces;
+using Cosmos.DataTransfer.Interfaces.Manifest;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.ComponentModel.DataAnnotations;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Cosmos.DataTransfer.Core.UnitTests
+{
+    [TestClass]
+    public class SettingsCommandTests
+    {
+        [TestMethod]
+        public void Invoke_ForTestExtension_ProducesValidSettingsJson()
+        {
+            var command = new SettingsCommand();
+            const string source = "testSource";
+            var loader = new Mock<IExtensionManifestBuilder>();
+            var sourceExtension = new Mock<IDataSourceExtensionWithSettings>();
+            sourceExtension.SetupGet(ds => ds.DisplayName).Returns(source);
+            sourceExtension.Setup(ds => ds.GetSettings()).Returns(new List<IDataExtensionSettings>
+            {
+                new MockExtensionSettings(),
+                new MockExtensionSettings2()
+            });
+            loader
+                .Setup(l => l.GetSources())
+                .Returns(new List<IDataSourceExtension> { sourceExtension.Object });
+
+            var writer = new Mock<IRawOutputWriter>();
+            var outputLines = new List<string>();
+            writer.Setup(w => w.WriteLine(It.IsAny<string>())).Callback<string>(s => outputLines.Add(s));
+            var handler = new SettingsCommand.CommandHandler(loader.Object, writer.Object, NullLogger<SettingsCommand.CommandHandler>.Instance)
+            {
+                Source = true,
+                Extension = source
+            };
+
+            var parseResult = new SettingsCommand().Parse(Array.Empty<string>());
+            var result = handler.Invoke(new InvocationContext(parseResult));
+            Assert.AreEqual(0, result);
+
+            bool jsonStarted = false;
+            var stringBuilder = new StringBuilder();
+            foreach (string item in outputLines)
+            {
+                if (item == "<<<")
+                    jsonStarted = true;
+                else if (item == ">>>")
+                    jsonStarted = false;
+                else if (jsonStarted)
+                    stringBuilder.AppendLine(item);
+            }
+
+            var options = new JsonSerializerOptions
+            {
+                Converters = { new JsonStringEnumConverter() },
+                WriteIndented = true
+            };
+            var fullJson = stringBuilder.ToString().Trim();
+            var parsed = JsonSerializer.Deserialize<List<ExtensionSettingProperty>>(fullJson, options);
+            var parsedJson = JsonSerializer.Serialize<List<ExtensionSettingProperty>>(parsed, options);
+
+            Assert.AreEqual(fullJson, parsedJson);
+        }
+    }
+
+    public class MockExtensionSettings : IDataExtensionSettings
+    {
+        [Required]
+        public string Name { get; set; } = null!;
+        public string? Description { get; set; }
+        public int Count { get; set; } = 99;
+        public int? MaxValue { get; set; }
+        public double? Avg { get; set; }
+        public bool Enabled { get; set; } = true;
+        public JsonCommentHandling TestEnum { get; set; }
+    }
+
+    public class MockExtensionSettings2 : IDataExtensionSettings
+    {
+        [Required]
+        public string? AnotherProperty { get; set; }
+    }
+}

--- a/Core/Cosmos.DataTransfer.Core/ExtensionManifestBuilder.cs
+++ b/Core/Cosmos.DataTransfer.Core/ExtensionManifestBuilder.cs
@@ -1,0 +1,136 @@
+﻿using Cosmos.DataTransfer.Interfaces;
+using Cosmos.DataTransfer.Interfaces.Manifest;
+using Microsoft.Extensions.Logging;
+using System;
+using System.ComponentModel.Composition.Hosting;
+using System.Reflection;
+
+namespace Cosmos.DataTransfer.Core
+{
+    public class ExtensionManifestBuilder : IExtensionManifestBuilder
+    {
+        private readonly ILogger _logger;
+        private readonly IExtensionLoader _extensionLoader;
+
+        public ExtensionManifestBuilder(IExtensionLoader extensionLoader, ILogger<ExtensionManifestBuilder> logger)
+        {
+            _extensionLoader = extensionLoader;
+            _logger = logger;
+        }
+
+        public List<IDataSourceExtension> GetSources()
+        {
+            string extensionsPath = _extensionLoader.GetExtensionFolderPath();
+            CompositionContainer container = _extensionLoader.BuildExtensionCatalog(extensionsPath);
+
+            return _extensionLoader.LoadExtensions<IDataSourceExtension>(container);
+        }
+
+        public List<IDataSinkExtension> GetSinks()
+        {
+            string extensionsPath = _extensionLoader.GetExtensionFolderPath();
+            CompositionContainer container = _extensionLoader.BuildExtensionCatalog(extensionsPath);
+
+            return _extensionLoader.LoadExtensions<IDataSinkExtension>(container);
+        }
+
+        public ExtensionManifest BuildManifest(ExtensionDirection direction)
+        {
+            var extensions = new List<IDataTransferExtension>();
+            if (direction == ExtensionDirection.Source)
+            {
+                extensions.AddRange(GetSources());
+            }
+            else
+            {
+                extensions.AddRange(GetSinks());
+            }
+            var manifest = new ExtensionManifest(extensions
+                .Select(e => new ExtensionManifestItem(e.DisplayName,
+                    direction,
+                    GetExtensionSettings(e as IExtensionWithSettings))).ToList());
+            return manifest;
+        }
+
+        public List<ExtensionSettingProperty> GetExtensionSettings(IExtensionWithSettings? extension)
+        {
+            var allProperties = new List<ExtensionSettingProperty>();
+            if (extension != null)
+            {
+                var allSettings = extension.GetSettings();
+                foreach (IDataExtensionSettings settings in allSettings)
+                {
+                    var settingsType = settings.GetType();
+
+                    var props = settingsType.GetProperties();
+                    foreach (PropertyInfo propertyInfo in props)
+                    {
+                        var defaultValue = propertyInfo.GetValue(settings);
+                        var settingProperty = new ExtensionSettingProperty(propertyInfo.Name, GetPropertyType(propertyInfo.PropertyType))
+                        {
+                            IsRequired = propertyInfo.GetCustomAttribute<System.ComponentModel.DataAnnotations.RequiredAttribute>() is not null,
+                            DefaultValue = defaultValue,
+                            IsSensitive = propertyInfo.GetCustomAttribute<SensitiveValueAttribute>() is not null
+                        };
+                        if (settingProperty.Type == PropertyType.Enum)
+                        {
+                            settingProperty.ValidValues.AddRange(GetPropertyEnumValues(propertyInfo, settings));
+                        }
+                        allProperties.Add(settingProperty);
+                    }
+                }
+            }
+
+            return allProperties;
+        }
+
+        private IEnumerable<string> GetPropertyEnumValues(PropertyInfo propertyInfo, IDataExtensionSettings settings)
+        {
+            if (propertyInfo.PropertyType.IsEnum)
+            {
+                return Enum.GetNames(propertyInfo.PropertyType);
+            }
+
+            return Enumerable.Empty<string>();
+        }
+
+        private static PropertyType GetPropertyType(Type type)
+        {
+            if (type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>))
+            {
+                var genericType = type.GetGenericArguments().FirstOrDefault();
+                if (genericType != null)
+                    type = genericType;
+            }
+
+            if (type == typeof(byte) || type == typeof(short) || type == typeof(ushort) ||
+                type == typeof(int) || type == typeof(uint) ||
+                type == typeof(long) || type == typeof(ulong))
+            {
+                return PropertyType.Int;
+            }
+
+            if (type == typeof(double) || type == typeof(float) || type == typeof(decimal))
+            {
+                return PropertyType.Float;
+            }
+
+            if (type == typeof(bool))
+            {
+                return PropertyType.Boolean;
+            }
+
+            if (type == typeof(DateTime) || type == typeof(DateTimeOffset))
+            {
+                return PropertyType.DateTime;
+            }
+
+            if (type.IsEnum)
+            {
+                return PropertyType.Enum;
+            }
+
+            return PropertyType.String;
+        }
+    }
+}

--- a/Core/Cosmos.DataTransfer.Core/IExtensionManifestBuilder.cs
+++ b/Core/Cosmos.DataTransfer.Core/IExtensionManifestBuilder.cs
@@ -1,0 +1,14 @@
+﻿using Cosmos.DataTransfer.Interfaces;
+using Cosmos.DataTransfer.Interfaces.Manifest;
+using System;
+
+namespace Cosmos.DataTransfer.Core
+{
+    public interface IExtensionManifestBuilder
+    {
+        ExtensionManifest BuildManifest(ExtensionDirection direction);
+        List<ExtensionSettingProperty> GetExtensionSettings(IExtensionWithSettings? extension);
+        List<IDataSinkExtension> GetSinks();
+        List<IDataSourceExtension> GetSources();
+    }
+}

--- a/Core/Cosmos.DataTransfer.Core/ListCommand.cs
+++ b/Core/Cosmos.DataTransfer.Core/ListCommand.cs
@@ -11,12 +11,30 @@ namespace Cosmos.DataTransfer.Core
         public ListCommand()
             : base("list", "Loads and lists all available extensions")
         {
+            AddListOptions(this);
+        }
+
+        public static void AddListOptions(Command command)
+        {
+            var sourcesOption = new Option<bool?>(
+                aliases: new[] { "--sources" },
+                description: "True to include source names");
+
+            var sinksOption = new Option<bool?>(
+                aliases: new[] { "--sinks" },
+                description: "True to include sink names");
+
+            command.AddOption(sourcesOption);
+            command.AddOption(sinksOption);
         }
 
         public class CommandHandler : ICommandHandler
         {
             private readonly ILogger<CommandHandler> _logger;
             private readonly IExtensionLoader _extensionLoader;
+
+            public bool? Sources { get; set; }
+            public bool? Sinks { get; set; }
 
             public CommandHandler(IExtensionLoader extensionLoader, ILogger<CommandHandler> logger)
             {
@@ -32,16 +50,25 @@ namespace Cosmos.DataTransfer.Core
                 var sources = _extensionLoader.LoadExtensions<IDataSourceExtension>(container);
                 var sinks = _extensionLoader.LoadExtensions<IDataSinkExtension>(container);
 
-                Console.WriteLine($"{sources.Count} Source Extensions");
-                foreach (var extension in sources)
+                bool showSources = Sources ?? (Sources == null && Sinks == null);
+                bool showSinks = Sinks ?? (Sources == null && Sinks == null);
+
+                if (showSources)
                 {
-                    Console.WriteLine($"\t{extension.DisplayName}");
+                    Console.WriteLine($"{sources.Count} Source Extensions");
+                    foreach (var extension in sources)
+                    {
+                        Console.WriteLine($"\t{extension.DisplayName}");
+                    }
                 }
 
-                Console.WriteLine($"{sinks.Count} Sink Extensions");
-                foreach (var extension in sinks)
+                if (showSinks)
                 {
-                    Console.WriteLine($"\t{extension.DisplayName}");
+                    Console.WriteLine($"{sinks.Count} Sink Extensions");
+                    foreach (var extension in sinks)
+                    {
+                        Console.WriteLine($"\t{extension.DisplayName}");
+                    }
                 }
 
                 return 0;

--- a/Core/Cosmos.DataTransfer.Core/Program.cs
+++ b/Core/Cosmos.DataTransfer.Core/Program.cs
@@ -19,6 +19,7 @@ class Program
         rootCommand.AddCommand(new RunCommand());
         rootCommand.AddCommand(new ListCommand());
         rootCommand.AddCommand(new InitCommand());
+        rootCommand.AddCommand(new SettingsCommand());
 
         // execute Run if no command provided
         RunCommand.AddRunOptions(rootCommand);
@@ -66,10 +67,13 @@ class Program
                 }).ConfigureServices((hostContext, services) =>
                 {
                     services.AddTransient<IExtensionLoader, ExtensionLoader>();
+                    services.AddTransient<IRawOutputWriter, ConsoleOutputWriter>();
+                    services.AddTransient<IExtensionManifestBuilder, ExtensionManifestBuilder>();
                 })
                     .UseCommandHandler<RunCommand, RunCommand.CommandHandler>()
                     .UseCommandHandler<ListCommand, ListCommand.CommandHandler>()
-                    .UseCommandHandler<InitCommand, InitCommand.CommandHandler>();
+                    .UseCommandHandler<InitCommand, InitCommand.CommandHandler>()
+                    .UseCommandHandler<SettingsCommand, SettingsCommand.CommandHandler>();
             })
             .UseHelp(AddAdditionalArgumentsHelp)
             .UseDefaults().Build();

--- a/Core/Cosmos.DataTransfer.Core/Properties/launchSettings.json
+++ b/Core/Cosmos.DataTransfer.Core/Properties/launchSettings.json
@@ -31,6 +31,10 @@
     "Parquet->JSON": {
       "commandName": "Project",
       "commandLineArgs": "run --sink json-file(beta) --source parquet --settings C:\\Temp\\Parquet-Json.json"
+    },
+    "SettingsCommand": {
+      "commandName": "Project",
+      "commandLineArgs": "settings --sink -e cosmos-nosql"
     }
   }
 }

--- a/Core/Cosmos.DataTransfer.Core/SettingsCommand.cs
+++ b/Core/Cosmos.DataTransfer.Core/SettingsCommand.cs
@@ -1,0 +1,142 @@
+﻿using System.CommandLine;
+using System.CommandLine.Invocation;
+using Cosmos.DataTransfer.Interfaces;
+using Microsoft.Extensions.Logging;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Cosmos.DataTransfer.Interfaces.Manifest;
+
+namespace Cosmos.DataTransfer.Core
+{
+    public class SettingsCommand : Command
+    {
+        public SettingsCommand()
+            : base("settings", "Loads and lists extension settings structure")
+        {
+            AddSettingsOptions(this);
+        }
+
+        public static void AddSettingsOptions(Command command)
+        {
+            var extensionOption = new Option<string?>(
+                aliases: new[] { "--extension", "-e" },
+                description: "The extension type to load.");
+
+            var sourcesOption = new Option<bool?>(
+                aliases: new[] { "--source" },
+                description: "True to include source settings");
+
+            var sinksOption = new Option<bool?>(
+                aliases: new[] { "--sink" },
+                description: "True to include sink settings");
+
+            var outputOption = new Option<FileInfo?>(
+                aliases: new[] { "--output", "-o" },
+                description: "The output path to write a manifest file.");
+
+            command.AddOption(extensionOption);
+            command.AddOption(sourcesOption);
+            command.AddOption(sinksOption);
+            command.AddOption(outputOption);
+        }
+
+        public class CommandHandler : ICommandHandler
+        {
+            private readonly ILogger<CommandHandler> _logger;
+            private readonly IExtensionManifestBuilder _manifestBuilder;
+            private readonly IRawOutputWriter _writer;
+
+            public string? Extension { get; set; }
+            public bool? Source { get; set; }
+            public bool? Sink { get; set; }
+            public FileInfo? Output { get; set; }
+
+            public CommandHandler(IExtensionManifestBuilder manifestBuilder, IRawOutputWriter rawOutputWriter, ILogger<CommandHandler> logger)
+            {
+                _logger = logger;
+                _manifestBuilder = manifestBuilder;
+                _writer = rawOutputWriter;
+            }
+
+            public int Invoke(InvocationContext context)
+            {
+                return InvokeAsync(context).GetAwaiter().GetResult();
+            }
+
+            public async Task<int> InvokeAsync(InvocationContext context)
+            {
+                if (Source.HasValue && Sink.HasValue || !(Source.HasValue || Sink.HasValue))
+                {
+                    throw new InvalidOperationException();
+                }
+
+                if (!string.IsNullOrWhiteSpace(Extension))
+                {
+                    if (Source == true)
+                    {
+                        var sources = _manifestBuilder.GetSources();
+                        var selectedSource = sources.FirstOrDefault(s => string.Equals(s.DisplayName, Extension, StringComparison.CurrentCultureIgnoreCase));
+                        if (selectedSource is IExtensionWithSettings extension)
+                        {
+                            var allProperties = _manifestBuilder.GetExtensionSettings(extension);
+
+                            await WriteOutput(allProperties);
+                        }
+                    }
+                    else if (Sink == true)
+                    {
+                        var sinks = _manifestBuilder.GetSinks();
+                        var selectedSink = sinks.FirstOrDefault(s => string.Equals(s.DisplayName, Extension, StringComparison.CurrentCultureIgnoreCase));
+                        if (selectedSink is IExtensionWithSettings extension)
+                        {
+                            var allProperties = _manifestBuilder.GetExtensionSettings(extension);
+
+                            await WriteOutput(allProperties);
+                        }
+                    }
+                }
+                else
+                {
+                    var manifest = _manifestBuilder.BuildManifest(Source == true ? ExtensionDirection.Source : ExtensionDirection.Sink);
+                    await WriteOutput(manifest);
+                }
+
+                return 0;
+            }
+
+            private async Task WriteOutput(object manifest)
+            {
+                var fullJson = JsonSerializer.Serialize(manifest, SerializerOptions);
+                if (Output == null)
+                {
+                    _writer.WriteLine("<<<");
+                    _writer.WriteLine(fullJson);
+                    _writer.WriteLine(">>>");
+                }
+                else
+                {
+                    await File.WriteAllTextAsync(Output.FullName, fullJson);
+                }
+            }
+
+            private static JsonSerializerOptions SerializerOptions => new()
+            {
+                Converters = { new JsonStringEnumConverter() },
+                WriteIndented = true
+            };
+        }
+    }
+
+    public interface IRawOutputWriter
+    {
+        void WriteLine(string? value);
+    }
+
+    public class ConsoleOutputWriter : IRawOutputWriter
+    {
+        public void WriteLine(string? value)
+        {
+            Console.WriteLine(value);
+        }
+    }
+}

--- a/Extensions/AwsS3/Cosmos.DataTransfer.AwsS3Storage/AwsS3DataSink.cs
+++ b/Extensions/AwsS3/Cosmos.DataTransfer.AwsS3Storage/AwsS3DataSink.cs
@@ -18,5 +18,10 @@ namespace Cosmos.DataTransfer.AwsS3Storage
             await writeToStream(stream);
             await S3Writer.WriteToS3(settings.S3BucketName, stream, settings.FileName, cancellationToken);
         }
+
+        public IEnumerable<IDataExtensionSettings> GetSettings()
+        {
+            yield return new AwsS3SinkSettings();
+        }
     }
 }

--- a/Extensions/AwsS3/Cosmos.DataTransfer.AwsS3Storage/AwsS3SinkSettings.cs
+++ b/Extensions/AwsS3/Cosmos.DataTransfer.AwsS3Storage/AwsS3SinkSettings.cs
@@ -1,4 +1,5 @@
 ﻿using Cosmos.DataTransfer.Interfaces;
+using Cosmos.DataTransfer.Interfaces.Manifest;
 using System.ComponentModel.DataAnnotations;
 
 namespace Cosmos.DataTransfer.AwsS3Storage
@@ -12,8 +13,10 @@ namespace Cosmos.DataTransfer.AwsS3Storage
         [Required]
         public string S3BucketName { get; set; } = null!;
         [Required]
+        [SensitiveValue]
         public string S3AccessKey { get; set; } = null!;
         [Required]
+        [SensitiveValue]
         public string S3SecretKey { get; set; } = null!;
     }
 }

--- a/Extensions/AzureBlob/Cosmos.DataTransfer.AzureBlobStorage/AzureBlobDataSink.cs
+++ b/Extensions/AzureBlob/Cosmos.DataTransfer.AzureBlobStorage/AzureBlobDataSink.cs
@@ -12,7 +12,7 @@ namespace Cosmos.DataTransfer.AzureBlobStorage
             settings.Validate();
 
             logger.LogInformation("Saving file '{File}' to Azure Blob Container '{ContainerName}'", settings.BlobName, settings.ContainerName);
-            BlobWriter.InitializeAzureBlobClient(settings.ConnectionString, settings.ContainerName, settings.BlobName);
+            await BlobWriter.InitializeAzureBlobClient(settings.ConnectionString, settings.ContainerName, settings.BlobName, cancellationToken);
             await using var stream = new MemoryStream();
             await writeToStream(stream);
             await BlobWriter.WriteToAzureBlob(stream.ToArray(), settings.MaxBlockSizeinKB, cancellationToken);

--- a/Extensions/AzureBlob/Cosmos.DataTransfer.AzureBlobStorage/AzureBlobDataSink.cs
+++ b/Extensions/AzureBlob/Cosmos.DataTransfer.AzureBlobStorage/AzureBlobDataSink.cs
@@ -17,5 +17,10 @@ namespace Cosmos.DataTransfer.AzureBlobStorage
             await writeToStream(stream);
             await BlobWriter.WriteToAzureBlob(stream.ToArray(), settings.MaxBlockSizeinKB, cancellationToken);
         }
+
+        public IEnumerable<IDataExtensionSettings> GetSettings()
+        {
+            yield return new AzureBlobSinkSettings();
+        }
     }
 }

--- a/Extensions/AzureBlob/Cosmos.DataTransfer.AzureBlobStorage/AzureBlobSinkSettings.cs
+++ b/Extensions/AzureBlob/Cosmos.DataTransfer.AzureBlobStorage/AzureBlobSinkSettings.cs
@@ -1,11 +1,13 @@
 ﻿using Cosmos.DataTransfer.Interfaces;
 using System.ComponentModel.DataAnnotations;
+using Cosmos.DataTransfer.Interfaces.Manifest;
 
 namespace Cosmos.DataTransfer.AzureBlobStorage
 {
     public class AzureBlobSinkSettings : IDataExtensionSettings
     {
         [Required]
+        [SensitiveValue]
         public string ConnectionString { get; set; } = null!;
 
         [Required]

--- a/Extensions/AzureBlob/Cosmos.DataTransfer.AzureBlobStorage/BlobWriter.cs
+++ b/Extensions/AzureBlob/Cosmos.DataTransfer.AzureBlobStorage/BlobWriter.cs
@@ -1,4 +1,5 @@
-﻿using Azure.Storage.Blobs.Specialized;
+﻿using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Specialized;
 
 namespace Cosmos.DataTransfer.AzureBlobStorage
 {
@@ -6,9 +7,11 @@ namespace Cosmos.DataTransfer.AzureBlobStorage
     {
         private static BlockBlobClient blob;
 
-        public static void InitializeAzureBlobClient(string connectionString, string containerName, string blobName)
+        public static async Task InitializeAzureBlobClient(string connectionString, string containerName, string blobName, CancellationToken cancellationToken)
         {
-            blob = new BlockBlobClient(connectionString, containerName, blobName);
+            var account = new BlobContainerClient(connectionString, containerName);
+            await account.CreateIfNotExistsAsync(cancellationToken: cancellationToken);
+            blob = account.GetBlockBlobClient(blobName);
         }
 
         public static async Task WriteToAzureBlob(byte[] fileContents, int? maxBlockSize, CancellationToken cancellationToken)

--- a/Extensions/AzureTableAPI/Cosmos.DataTransfer.AzureTableAPIExtension/AzureTableAPIDataSinkExtension.cs
+++ b/Extensions/AzureTableAPI/Cosmos.DataTransfer.AzureTableAPIExtension/AzureTableAPIDataSinkExtension.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Logging;
 namespace Cosmos.DataTransfer.AzureTableAPIExtension
 {
     [Export(typeof(IDataSinkExtension))]
-    public class AzureTableAPIDataSinkExtension : IDataSinkExtension
+    public class AzureTableAPIDataSinkExtension : IDataSinkExtensionWithSettings
     {
         public string DisplayName => "AzureTableAPI";
 
@@ -31,6 +31,11 @@ namespace Cosmos.DataTransfer.AzureTableAPIExtension
             }
 
             await Task.WhenAll(createTasks);
+        }
+
+        public IEnumerable<IDataExtensionSettings> GetSettings()
+        {
+            yield return new AzureTableAPIDataSinkSettings();
         }
     }
 }

--- a/Extensions/AzureTableAPI/Cosmos.DataTransfer.AzureTableAPIExtension/AzureTableAPIDataSourceExtension.cs
+++ b/Extensions/AzureTableAPI/Cosmos.DataTransfer.AzureTableAPIExtension/AzureTableAPIDataSourceExtension.cs
@@ -11,7 +11,7 @@ using Microsoft.Extensions.Logging;
 namespace Cosmos.DataTransfer.AzureTableAPIExtension
 {
     [Export(typeof(IDataSourceExtension))]
-    public class AzureTableAPIDataSourceExtension : IDataSourceExtension
+    public class AzureTableAPIDataSourceExtension : IDataSourceExtensionWithSettings
     {
         public string DisplayName => "AzureTableAPI";
 
@@ -40,6 +40,11 @@ namespace Cosmos.DataTransfer.AzureTableAPIExtension
             //{
             //    yield return new AzureTableAPIDataItem(enumerator.Current, settings.PartitionKeyFieldName, settings.RowKeyFieldName);
             //} while (await enumerator.MoveNextAsync());
+        }
+
+        public IEnumerable<IDataExtensionSettings> GetSettings()
+        {
+            yield return new AzureTableAPIDataSourceSettings();
         }
     }
 }

--- a/Extensions/AzureTableAPI/Cosmos.DataTransfer.AzureTableAPIExtension/Settings/AzureTableAPISettingsBase.cs
+++ b/Extensions/AzureTableAPI/Cosmos.DataTransfer.AzureTableAPIExtension/Settings/AzureTableAPISettingsBase.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using Cosmos.DataTransfer.Interfaces;
+using Cosmos.DataTransfer.Interfaces.Manifest;
 
 namespace Cosmos.DataTransfer.AzureTableAPIExtension.Settings
 {
@@ -9,6 +10,7 @@ namespace Cosmos.DataTransfer.AzureTableAPIExtension.Settings
         /// The Connection String.
         /// </summary>
         [Required]
+        [SensitiveValue]
         public string? ConnectionString { get; set; }
 
         /// <summary>

--- a/Extensions/CognitiveSearch/Cosmos.DataTransfer.CognitiveSearchExtension/CognitiveSearchDataSinkExtension.cs
+++ b/Extensions/CognitiveSearch/Cosmos.DataTransfer.CognitiveSearchExtension/CognitiveSearchDataSinkExtension.cs
@@ -13,7 +13,7 @@ using System.Dynamic;
 namespace Cosmos.DataTransfer.CognitiveSearchExtension
 {
     [Export(typeof(IDataSinkExtension))]
-    public class CognitiveSearchDataSinkExtension : IDataSinkExtension
+    public class CognitiveSearchDataSinkExtension : IDataSinkExtensionWithSettings
     {
         public string DisplayName => "CognitiveSearch";
 
@@ -90,6 +90,11 @@ namespace Cosmos.DataTransfer.CognitiveSearchExtension
             }
 
             return item;
+        }
+
+        public IEnumerable<IDataExtensionSettings> GetSettings()
+        {
+            yield return new CognitiveSearchDataSinkSettings();
         }
     }
 }

--- a/Extensions/CognitiveSearch/Cosmos.DataTransfer.CognitiveSearchExtension/CognitiveSearchDataSourceExtension.cs
+++ b/Extensions/CognitiveSearch/Cosmos.DataTransfer.CognitiveSearchExtension/CognitiveSearchDataSourceExtension.cs
@@ -11,7 +11,7 @@ using System.Text.Json;
 namespace Cosmos.DataTransfer.CognitiveSearchExtension
 {
     [Export(typeof(IDataSourceExtension))]
-    public class CognitiveSearchDataSourceExtension : IDataSourceExtension
+    public class CognitiveSearchDataSourceExtension : IDataSourceExtensionWithSettings
     {
         public string DisplayName => "CognitiveSearch";
 
@@ -34,6 +34,11 @@ namespace Cosmos.DataTransfer.CognitiveSearchExtension
             {
                 yield return new CognitiveSearchDataItem(searchResult.Document);
             }
+        }
+
+        public IEnumerable<IDataExtensionSettings> GetSettings()
+        {
+            yield return new CognitiveSearchDataSourceSettings();
         }
     }
 }

--- a/Extensions/CognitiveSearch/Cosmos.DataTransfer.CognitiveSearchExtension/Settings/CognitiveSearchSettingsBase.cs
+++ b/Extensions/CognitiveSearch/Cosmos.DataTransfer.CognitiveSearchExtension/Settings/CognitiveSearchSettingsBase.cs
@@ -1,4 +1,5 @@
 ﻿using Cosmos.DataTransfer.Interfaces;
+using Cosmos.DataTransfer.Interfaces.Manifest;
 using System.ComponentModel.DataAnnotations;
 
 namespace Cosmos.DataTransfer.CognitiveSearchExtension.Settings
@@ -17,6 +18,7 @@ namespace Cosmos.DataTransfer.CognitiveSearchExtension.Settings
         /// for Source admin key or query key
         /// </summary>
         [Required]
+        [SensitiveValue]
         public string? ApiKey { get; set; }
 
         /// <summary>

--- a/Extensions/Cosmos/Cosmos.DataTransfer.CosmosExtension/CosmosDataSinkExtension.cs
+++ b/Extensions/Cosmos/Cosmos.DataTransfer.CosmosExtension/CosmosDataSinkExtension.cs
@@ -16,7 +16,7 @@ using Polly.Retry;
 namespace Cosmos.DataTransfer.CosmosExtension
 {
     [Export(typeof(IDataSinkExtension))]
-    public class CosmosDataSinkExtension : IDataSinkExtension
+    public class CosmosDataSinkExtension : IDataSinkExtensionWithSettings
     {
         public string DisplayName => "Cosmos-nosql";
 
@@ -227,6 +227,11 @@ namespace Cosmos.DataTransfer.CosmosExtension
             }
 
             return item;
+        }
+
+        public IEnumerable<IDataExtensionSettings> GetSettings()
+        {
+            yield return new CosmosSinkSettings();
         }
     }
 }

--- a/Extensions/Cosmos/Cosmos.DataTransfer.CosmosExtension/CosmosDataSourceExtension.cs
+++ b/Extensions/Cosmos/Cosmos.DataTransfer.CosmosExtension/CosmosDataSourceExtension.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Logging;
 namespace Cosmos.DataTransfer.CosmosExtension
 {
     [Export(typeof(IDataSourceExtension))]
-    public class CosmosDataSourceExtension : IDataSourceExtension
+    public class CosmosDataSourceExtension : IDataSourceExtensionWithSettings
     {
         public string DisplayName => "Cosmos-nosql";
 
@@ -58,6 +58,11 @@ namespace Cosmos.DataTransfer.CosmosExtension
             }
 
             return container.GetItemQueryIterator<T>(settings.Query, requestOptions: requestOptions);
+        }
+
+        public IEnumerable<IDataExtensionSettings> GetSettings()
+        {
+            yield return new CosmosSourceSettings();
         }
     }
 }

--- a/Extensions/Cosmos/Cosmos.DataTransfer.CosmosExtension/CosmosSinkSettings.cs
+++ b/Extensions/Cosmos/Cosmos.DataTransfer.CosmosExtension/CosmosSinkSettings.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using Cosmos.DataTransfer.Interfaces;
+using Cosmos.DataTransfer.Interfaces.Manifest;
 using Microsoft.Azure.Cosmos;
 
 namespace Cosmos.DataTransfer.CosmosExtension
@@ -7,6 +8,7 @@ namespace Cosmos.DataTransfer.CosmosExtension
     public class CosmosSinkSettings : IDataExtensionSettings
     {
         [Required]
+        [SensitiveValue]
         public string? ConnectionString { get; set; }
         [Required]
         public string? Database { get; set; }

--- a/Extensions/Cosmos/Cosmos.DataTransfer.CosmosExtension/CosmosSourceSettings.cs
+++ b/Extensions/Cosmos/Cosmos.DataTransfer.CosmosExtension/CosmosSourceSettings.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using Cosmos.DataTransfer.Interfaces;
+using Cosmos.DataTransfer.Interfaces.Manifest;
 using Microsoft.Azure.Cosmos;
 
 namespace Cosmos.DataTransfer.CosmosExtension
@@ -7,6 +8,7 @@ namespace Cosmos.DataTransfer.CosmosExtension
     public class CosmosSourceSettings : IDataExtensionSettings
     {
         [Required]
+        [SensitiveValue]
         public string? ConnectionString { get; set; }
         [Required]
         public string? Database { get; set; }

--- a/Extensions/Json/Cosmos.DataTransfer.JsonExtension/JsonDataSinkExtension.cs
+++ b/Extensions/Json/Cosmos.DataTransfer.JsonExtension/JsonDataSinkExtension.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Logging;
 namespace Cosmos.DataTransfer.JsonExtension
 {
     [Export(typeof(IDataSinkExtension))]
-    public class JsonDataSinkExtension : IDataSinkExtension
+    public class JsonDataSinkExtension : IDataSinkExtensionWithSettings
     {
         public string DisplayName => "JSON";
 
@@ -41,6 +41,11 @@ namespace Cosmos.DataTransfer.JsonExtension
             }
 
             writer.WriteEndArray();
+        }
+
+        public IEnumerable<IDataExtensionSettings> GetSettings()
+        {
+            yield return new JsonSinkSettings();
         }
     }
 }

--- a/Extensions/Json/Cosmos.DataTransfer.JsonExtension/JsonDataSourceExtension.cs
+++ b/Extensions/Json/Cosmos.DataTransfer.JsonExtension/JsonDataSourceExtension.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Logging;
 namespace Cosmos.DataTransfer.JsonExtension
 {
     [Export(typeof(IDataSourceExtension))]
-    public class JsonDataSourceExtension : IDataSourceExtension
+    public class JsonDataSourceExtension : IDataSourceExtension//WithSettings // disabled for now to enable UI testing of missing settings
     {
         public string DisplayName => "JSON";
         public async IAsyncEnumerable<IDataItem> ReadAsync(IConfiguration config, ILogger logger, [EnumeratorCancellation] CancellationToken cancellationToken = default)
@@ -157,6 +157,11 @@ namespace Cosmos.DataTransfer.JsonExtension
             logger.LogWarning("No records read from '{Content}'", textContent);
 
             return null;
+        }
+
+        public IEnumerable<IDataExtensionSettings> GetSettings()
+        {
+            yield return new JsonSourceSettings();
         }
     }
 }

--- a/Extensions/Json/Cosmos.DataTransfer.JsonExtension/JsonFormatReader.cs
+++ b/Extensions/Json/Cosmos.DataTransfer.JsonExtension/JsonFormatReader.cs
@@ -96,4 +96,9 @@ public class JsonFormatReader : IFormattedDataReader
 
         return textContent;
     }
+
+    public IEnumerable<IDataExtensionSettings> GetSettings()
+    {
+        yield break;
+    }
 }

--- a/Extensions/Json/Cosmos.DataTransfer.JsonExtension/JsonFormatWriter.cs
+++ b/Extensions/Json/Cosmos.DataTransfer.JsonExtension/JsonFormatWriter.cs
@@ -26,4 +26,9 @@ public class JsonFormatWriter : IFormattedDataWriter
 
         writer.WriteEndArray();
     }
+
+    public IEnumerable<IDataExtensionSettings> GetSettings()
+    {
+        yield return new JsonFormatWriterSettings();
+    }
 }

--- a/Extensions/Mongo/Cosmos.DataTransfer.MongoExtension/MongoDataSinkExtension.cs
+++ b/Extensions/Mongo/Cosmos.DataTransfer.MongoExtension/MongoDataSinkExtension.cs
@@ -7,7 +7,7 @@ using MongoDB.Bson;
 
 namespace Cosmos.DataTransfer.MongoExtension;
 [Export(typeof(IDataSinkExtension))]
-public class MongoDataSinkExtension : IDataSinkExtension
+public class MongoDataSinkExtension : IDataSinkExtensionWithSettings
 {
     public string DisplayName => "MongoDB";
 
@@ -41,5 +41,10 @@ public class MongoDataSinkExtension : IDataSinkExtension
                 await repo.AddRange(objects);
             }
         }
+    }
+
+    public IEnumerable<IDataExtensionSettings> GetSettings()
+    {
+        yield return new MongoSinkSettings();
     }
 }

--- a/Extensions/Mongo/Cosmos.DataTransfer.MongoExtension/MongoDataSourceExtension.cs
+++ b/Extensions/Mongo/Cosmos.DataTransfer.MongoExtension/MongoDataSourceExtension.cs
@@ -8,7 +8,7 @@ using MongoDB.Bson;
 
 namespace Cosmos.DataTransfer.MongoExtension;
 [Export(typeof(IDataSourceExtension))]
-internal class MongoDataSourceExtension : IDataSourceExtension
+internal class MongoDataSourceExtension : IDataSourceExtensionWithSettings
 {
     public string DisplayName => "MongoDB";
 
@@ -42,5 +42,10 @@ internal class MongoDataSourceExtension : IDataSourceExtension
         {
             yield return new MongoDataItem(record);
         }
+    }
+
+    public IEnumerable<IDataExtensionSettings> GetSettings()
+    {
+        yield return new MongoSourceSettings();
     }
 }

--- a/Extensions/Mongo/Cosmos.DataTransfer.MongoExtension/Settings/MongoBaseSettings.cs
+++ b/Extensions/Mongo/Cosmos.DataTransfer.MongoExtension/Settings/MongoBaseSettings.cs
@@ -1,10 +1,12 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using Cosmos.DataTransfer.Interfaces;
+using Cosmos.DataTransfer.Interfaces.Manifest;
 
 namespace Cosmos.DataTransfer.MongoExtension.Settings;
 public class MongoBaseSettings : IDataExtensionSettings
 {
     [Required]
+    [SensitiveValue]
     public string? ConnectionString { get; set; }
 
     [Required]

--- a/Extensions/Parquet/Cosmos.DataTransfer.ParquetExtension/ParquetFormatReader.cs
+++ b/Extensions/Parquet/Cosmos.DataTransfer.ParquetExtension/ParquetFormatReader.cs
@@ -61,5 +61,10 @@ namespace Cosmos.DataTransfer.ParquetExtension
                 logger.LogInformation("Completed reading source file");
             }
         }
+
+        public IEnumerable<IDataExtensionSettings> GetSettings()
+        {
+            yield return new ParquetSourceSettings();
+        }
     }
 }

--- a/Extensions/Parquet/Cosmos.DataTransfer.ParquetExtension/ParquetFormatWriter.cs
+++ b/Extensions/Parquet/Cosmos.DataTransfer.ParquetExtension/ParquetFormatWriter.cs
@@ -124,5 +124,10 @@ namespace Cosmos.DataTransfer.ParquetExtension
                 }
             }
         }
+
+        public IEnumerable<IDataExtensionSettings> GetSettings()
+        {
+            yield return new ParquetSinkSettings();
+        }
     }
 }

--- a/Extensions/SqlServer/Cosmos.DataTransfer.SqlServerExtension/ColumnMapping.cs
+++ b/Extensions/SqlServer/Cosmos.DataTransfer.SqlServerExtension/ColumnMapping.cs
@@ -12,7 +12,7 @@ namespace Cosmos.DataTransfer.SqlServerExtension
 
         public string? GetFieldName()
         {
-            return SourceFieldName ?? ColumnName;
+            return !string.IsNullOrEmpty(SourceFieldName) ? SourceFieldName : ColumnName;
         }
     }
 }

--- a/Extensions/SqlServer/Cosmos.DataTransfer.SqlServerExtension/SqlServerDataSinkExtension.cs
+++ b/Extensions/SqlServer/Cosmos.DataTransfer.SqlServerExtension/SqlServerDataSinkExtension.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Logging;
 namespace Cosmos.DataTransfer.SqlServerExtension
 {
     [Export(typeof(IDataSinkExtension))]
-    public class SqlServerDataSinkExtension : IDataSinkExtension
+    public class SqlServerDataSinkExtension : IDataSinkExtensionWithSettings
     {
         public string DisplayName => "SqlServer";
 
@@ -91,6 +91,11 @@ namespace Cosmos.DataTransfer.SqlServerExtension
             }
 
             await connection.CloseAsync();
+        }
+
+        public IEnumerable<IDataExtensionSettings> GetSettings()
+        {
+            yield return new SqlServerSinkSettings();
         }
     }
 }

--- a/Extensions/SqlServer/Cosmos.DataTransfer.SqlServerExtension/SqlServerDataSourceExtension.cs
+++ b/Extensions/SqlServer/Cosmos.DataTransfer.SqlServerExtension/SqlServerDataSourceExtension.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Logging;
 namespace Cosmos.DataTransfer.SqlServerExtension
 {
     [Export(typeof(IDataSourceExtension))]
-    public class SqlServerDataSourceExtension : IDataSourceExtension
+    public class SqlServerDataSourceExtension : IDataSourceExtensionWithSettings
     {
         public string DisplayName => "SqlServer";
 
@@ -36,6 +36,11 @@ namespace Cosmos.DataTransfer.SqlServerExtension
                 }
                 yield return new DictionaryDataItem(fields);
             }
+        }
+
+        public IEnumerable<IDataExtensionSettings> GetSettings()
+        {
+            yield return new SqlServerSourceSettings();
         }
     }
 }

--- a/Extensions/SqlServer/Cosmos.DataTransfer.SqlServerExtension/SqlServerSinkSettings.cs
+++ b/Extensions/SqlServer/Cosmos.DataTransfer.SqlServerExtension/SqlServerSinkSettings.cs
@@ -1,11 +1,13 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using Cosmos.DataTransfer.Interfaces;
+using Cosmos.DataTransfer.Interfaces.Manifest;
 
 namespace Cosmos.DataTransfer.SqlServerExtension
 {
     public class SqlServerSinkSettings : IDataExtensionSettings
     {
         [Required]
+        [SensitiveValue]
         public string? ConnectionString { get; set; }
         [Required]
         public string? TableName { get; set; }

--- a/Extensions/SqlServer/Cosmos.DataTransfer.SqlServerExtension/SqlServerSourceSettings.cs
+++ b/Extensions/SqlServer/Cosmos.DataTransfer.SqlServerExtension/SqlServerSourceSettings.cs
@@ -1,11 +1,13 @@
 ﻿using System.ComponentModel.DataAnnotations;
 using Cosmos.DataTransfer.Interfaces;
+using Cosmos.DataTransfer.Interfaces.Manifest;
 
 namespace Cosmos.DataTransfer.SqlServerExtension
 {
     public class SqlServerSourceSettings : IDataExtensionSettings
     {
         [Required]
+        [SensitiveValue]
         public string? ConnectionString { get; set; }
 
         [Required]

--- a/Interfaces/Cosmos.DataTransfer.Common/CompositeSinkExtension.cs
+++ b/Interfaces/Cosmos.DataTransfer.Common/CompositeSinkExtension.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Cosmos.DataTransfer.Common;
 
-public abstract class CompositeSinkExtension<TSink, TFormatter> : IDataSinkExtension
+public abstract class CompositeSinkExtension<TSink, TFormatter> : IDataSinkExtensionWithSettings
     where TSink : class, IComposableDataSink, new()
     where TFormatter : class, IFormattedDataWriter, new()
 {
@@ -21,5 +21,10 @@ public abstract class CompositeSinkExtension<TSink, TFormatter> : IDataSinkExten
         }
 
         await sink.WriteToTargetAsync(WriteToStream, config, dataSource, logger, cancellationToken);
+    }
+
+    public IEnumerable<IDataExtensionSettings> GetSettings()
+    {
+        return ExtensionHelpers.GetCompositeSettings<TFormatter, TSink>();
     }
 }

--- a/Interfaces/Cosmos.DataTransfer.Common/CompositeSourceExtension.cs
+++ b/Interfaces/Cosmos.DataTransfer.Common/CompositeSourceExtension.cs
@@ -4,7 +4,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Cosmos.DataTransfer.Common
 {
-    public abstract class CompositeSourceExtension<TSource, TFormatter> : IDataSourceExtension
+    public abstract class CompositeSourceExtension<TSource, TFormatter> : IDataSourceExtensionWithSettings
         where TSource : class, IComposableDataSource, new()
         where TFormatter : class, IFormattedDataReader, new()
     {
@@ -16,6 +16,11 @@ namespace Cosmos.DataTransfer.Common
             var formatter = new TFormatter();
 
             return formatter.ParseDataAsync(source, config, logger, cancellationToken);
+        }
+
+        public IEnumerable<IDataExtensionSettings> GetSettings()
+        {
+            return ExtensionHelpers.GetCompositeSettings<TFormatter, TSource>();
         }
     }
 }

--- a/Interfaces/Cosmos.DataTransfer.Common/ExtensionHelpers.cs
+++ b/Interfaces/Cosmos.DataTransfer.Common/ExtensionHelpers.cs
@@ -1,0 +1,20 @@
+﻿using Cosmos.DataTransfer.Interfaces;
+
+namespace Cosmos.DataTransfer.Common
+{
+    public static class ExtensionHelpers
+    {
+        public static IEnumerable<IDataExtensionSettings> GetCompositeSettings<TFormatter, TStorage>()
+            where TFormatter : class, IExtensionWithSettings, new()
+            where TStorage : class, IExtensionWithSettings, new()
+        {
+            var formatter = new TFormatter();
+            var source = new TStorage();
+            foreach (var settings in formatter.GetSettings().Concat(source.GetSettings()))
+            {
+                yield return settings;
+            }
+        }
+
+    }
+}

--- a/Interfaces/Cosmos.DataTransfer.Common/FileDataSink.cs
+++ b/Interfaces/Cosmos.DataTransfer.Common/FileDataSink.cs
@@ -16,4 +16,9 @@ public class FileDataSink : IComposableDataSink
             await writeToStream(writer);
         }
     }
+
+    public IEnumerable<IDataExtensionSettings> GetSettings()
+    {
+        yield return new FileSinkSettings();
+    }
 }

--- a/Interfaces/Cosmos.DataTransfer.Common/FileDataSource.cs
+++ b/Interfaces/Cosmos.DataTransfer.Common/FileDataSource.cs
@@ -53,4 +53,9 @@ public class FileDataSource : IComposableDataSource
             logger.LogInformation("Completed reading '{FilePath}'", settings.FilePath);
         }
     }
+
+    public IEnumerable<IDataExtensionSettings> GetSettings()
+    {
+        yield return new FileSourceSettings();
+    }
 }

--- a/Interfaces/Cosmos.DataTransfer.Interfaces/IComposableDataSink.cs
+++ b/Interfaces/Cosmos.DataTransfer.Interfaces/IComposableDataSink.cs
@@ -3,7 +3,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Cosmos.DataTransfer.Interfaces;
 
-public interface IComposableDataSink
+public interface IComposableDataSink : IExtensionWithSettings
 {
     Task WriteToTargetAsync(Func<Stream, Task> writeToStream, IConfiguration config, IDataSourceExtension dataSource, ILogger logger, CancellationToken cancellationToken = default);
 }

--- a/Interfaces/Cosmos.DataTransfer.Interfaces/IComposableDataSource.cs
+++ b/Interfaces/Cosmos.DataTransfer.Interfaces/IComposableDataSource.cs
@@ -3,7 +3,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Cosmos.DataTransfer.Interfaces;
 
-public interface IComposableDataSource
+public interface IComposableDataSource : IExtensionWithSettings
 {
     IAsyncEnumerable<Stream?> ReadSourceAsync(IConfiguration config, ILogger logger, CancellationToken cancellationToken = default);
 }

--- a/Interfaces/Cosmos.DataTransfer.Interfaces/IDataSinkExtension.cs
+++ b/Interfaces/Cosmos.DataTransfer.Interfaces/IDataSinkExtension.cs
@@ -7,4 +7,7 @@ namespace Cosmos.DataTransfer.Interfaces
     {
         Task WriteAsync(IAsyncEnumerable<IDataItem> dataItems, IConfiguration config, IDataSourceExtension dataSource, ILogger logger, CancellationToken cancellationToken = default);
     }
+    public interface IDataSinkExtensionWithSettings : IDataSinkExtension, IExtensionWithSettings
+    {
+    }
 }

--- a/Interfaces/Cosmos.DataTransfer.Interfaces/IDataSourceExtension.cs
+++ b/Interfaces/Cosmos.DataTransfer.Interfaces/IDataSourceExtension.cs
@@ -7,4 +7,8 @@ namespace Cosmos.DataTransfer.Interfaces
     {
         IAsyncEnumerable<IDataItem> ReadAsync(IConfiguration config, ILogger logger, CancellationToken cancellationToken = default);
     }
+
+    public interface IDataSourceExtensionWithSettings : IDataSourceExtension, IExtensionWithSettings
+    {
+    }
 }

--- a/Interfaces/Cosmos.DataTransfer.Interfaces/IExtensionWithSettings.cs
+++ b/Interfaces/Cosmos.DataTransfer.Interfaces/IExtensionWithSettings.cs
@@ -1,0 +1,7 @@
+﻿namespace Cosmos.DataTransfer.Interfaces
+{
+    public interface IExtensionWithSettings
+    {
+        IEnumerable<IDataExtensionSettings> GetSettings();
+    }
+}

--- a/Interfaces/Cosmos.DataTransfer.Interfaces/IFormattedDataReader.cs
+++ b/Interfaces/Cosmos.DataTransfer.Interfaces/IFormattedDataReader.cs
@@ -3,7 +3,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Cosmos.DataTransfer.Interfaces;
 
-public interface IFormattedDataReader
+public interface IFormattedDataReader : IExtensionWithSettings
 {
     IAsyncEnumerable<IDataItem> ParseDataAsync(IComposableDataSource sourceExtension, IConfiguration config, ILogger logger, CancellationToken cancellationToken = default);
 }

--- a/Interfaces/Cosmos.DataTransfer.Interfaces/IFormattedDataWriter.cs
+++ b/Interfaces/Cosmos.DataTransfer.Interfaces/IFormattedDataWriter.cs
@@ -3,7 +3,7 @@ using Microsoft.Extensions.Logging;
 
 namespace Cosmos.DataTransfer.Interfaces;
 
-public interface IFormattedDataWriter
+public interface IFormattedDataWriter : IExtensionWithSettings
 {
     Task FormatDataAsync(IAsyncEnumerable<IDataItem> dataItems, Stream target, IConfiguration config, ILogger logger, CancellationToken cancellationToken = default);
 }

--- a/Interfaces/Cosmos.DataTransfer.Interfaces/Manifest/ExtensionDirection.cs
+++ b/Interfaces/Cosmos.DataTransfer.Interfaces/Manifest/ExtensionDirection.cs
@@ -1,0 +1,7 @@
+﻿namespace Cosmos.DataTransfer.Interfaces.Manifest;
+
+public enum ExtensionDirection
+{
+    Source,
+    Sink,
+}

--- a/Interfaces/Cosmos.DataTransfer.Interfaces/Manifest/ExtensionManifest.cs
+++ b/Interfaces/Cosmos.DataTransfer.Interfaces/Manifest/ExtensionManifest.cs
@@ -1,0 +1,6 @@
+﻿namespace Cosmos.DataTransfer.Interfaces.Manifest;
+
+public record ExtensionManifest(IEnumerable<ExtensionManifestItem> Extensions)
+{
+    public static readonly ExtensionManifest Empty = new(Enumerable.Empty<ExtensionManifestItem>());
+}

--- a/Interfaces/Cosmos.DataTransfer.Interfaces/Manifest/ExtensionManifestItem.cs
+++ b/Interfaces/Cosmos.DataTransfer.Interfaces/Manifest/ExtensionManifestItem.cs
@@ -1,0 +1,6 @@
+﻿namespace Cosmos.DataTransfer.Interfaces.Manifest;
+
+public record ExtensionManifestItem(string Name, ExtensionDirection Direction, IEnumerable<ExtensionSettingProperty> Settings)
+{
+
+}

--- a/Interfaces/Cosmos.DataTransfer.Interfaces/Manifest/ExtensionSettingProperty.cs
+++ b/Interfaces/Cosmos.DataTransfer.Interfaces/Manifest/ExtensionSettingProperty.cs
@@ -1,0 +1,8 @@
+﻿namespace Cosmos.DataTransfer.Interfaces.Manifest;
+
+public record ExtensionSettingProperty(string Name, PropertyType Type, object? DefaultValue = null, bool IsRequired = false, bool IsSensitive = false)
+{
+    public static ExtensionSettingProperty Empty = new("--", PropertyType.Undeclared);
+
+    public List<string> ValidValues { get; init; } = new();
+}

--- a/Interfaces/Cosmos.DataTransfer.Interfaces/Manifest/PropertyType.cs
+++ b/Interfaces/Cosmos.DataTransfer.Interfaces/Manifest/PropertyType.cs
@@ -1,0 +1,12 @@
+﻿namespace Cosmos.DataTransfer.Interfaces.Manifest;
+
+public enum PropertyType
+{
+    String,
+    Boolean,
+    Int,
+    Float,
+    DateTime,
+    Enum,
+    Undeclared,
+}

--- a/Interfaces/Cosmos.DataTransfer.Interfaces/Manifest/SensitiveValueAttribute.cs
+++ b/Interfaces/Cosmos.DataTransfer.Interfaces/Manifest/SensitiveValueAttribute.cs
@@ -1,0 +1,5 @@
+﻿namespace Cosmos.DataTransfer.Interfaces.Manifest;
+
+public class SensitiveValueAttribute : Attribute
+{
+}


### PR DESCRIPTION
In order to support future GUI, adds a new "settings" command that gathers lists of settings from extensions and outputs them either at the command line or to a file. Settings include details appropriate to support validated input in order to build runnable commands or migrationsettings files.

Other bug fixes:
- For Azure Blob Storage, now ensures that container exists before writing
- For SQL Server, fixes config file issue where null field names would be used as empty string instead of falling back to column name