### PR TITLE
introduce DataWriteMode.Delete to undo inserts to the wrong container

### DIFF
--- a/Extensions/Cosmos/Cosmos.DataTransfer.CosmosExtension/DataWriteMode.cs
+++ b/Extensions/Cosmos/Cosmos.DataTransfer.CosmosExtension/DataWriteMode.cs
@@ -6,5 +6,7 @@
         Insert,
         UpsertStream,
         Upsert,
+        DeleteStream,
+        Delete
     }
 }

--- a/Extensions/Cosmos/README.md
+++ b/Extensions/Cosmos/README.md
@@ -44,7 +44,17 @@ Or with RBAC:
 }
 ```
 
-Sink requires an additional `PartitionKeyPath` parameter which is used when creating the container if it does not exist. To use hierarchical partition keys, instead use the `PartitionKeyPaths` setting to supply an array of up to 3 paths. It also supports an optional `RecreateContainer` parameter (`false` by default) to delete and then recreate the container to ensure only newly imported data is present. The optional `BatchSize` parameter (100 by default) sets the number of items to accumulate before inserting. `ConnectionMode` can be set to either `Gateway` (default) or `Direct` to control how the client connects to the CosmosDB service. For situations where a container is created as part of the transfer operation `CreatedContainerMaxThroughput` (in RUs) and `UseAutoscaleForCreatedContainer` provide the initial throughput settings which will be in effect when executing the transfer. To instead use shared throughput that has been provisioned at the database level, set the `UseSharedThroughput` parameter to `true`. The optional `WriteMode` parameter specifies the type of data write to use: `InsertStream`, `Insert`, `UpsertStream`, or `Upsert`. The `IsServerlessAccount` parameter specifies whether the target account uses Serverless instead of Provisioned throughput, which affects the way containers are created. Additional parameters allow changing the behavior of the Cosmos client appropriate to your environment.
+Sink requires an additional `PartitionKeyPath` parameter which is used when creating the container if it does not exist. To use hierarchical partition keys, instead use the `PartitionKeyPaths` setting to supply an array of up to 3 paths. It also supports an optional `RecreateContainer` parameter (`false` by default) to delete and then recreate the container to ensure only newly imported data is present. 
+
+The optional `BatchSize` parameter (100 by default) sets the number of items to accumulate before inserting. 
+
+`ConnectionMode` can be set to either `Gateway` (default) or `Direct` to control how the client connects to the CosmosDB service. 
+
+For situations where a container is created as part of the transfer operation `CreatedContainerMaxThroughput` (in RUs) and `UseAutoscaleForCreatedContainer` provide the initial throughput settings which will be in effect when executing the transfer. To instead use shared throughput that has been provisioned at the database level, set the `UseSharedThroughput` parameter to `true`. 
+
+The optional `WriteMode` parameter specifies the type of data write to use: `InsertStream`, `Insert`, `UpsertStream`, `Upsert`, `DeleteStream` or `Delete`. The latter is useful to undo inserts that might have been written to the wrong container by mistake, if you cannot delete the entire container because it might contain other unrelated data.  
+
+The `IsServerlessAccount` parameter specifies whether the target account uses Serverless instead of Provisioned throughput, which affects the way containers are created. Additional parameters allow changing the behavior of the Cosmos client appropriate to your environment.
 
 ### Sink
 


### PR DESCRIPTION
`Delete` is useful to undo inserts that might have been written to the wrong container by mistake, if you cannot delete the entire container because it might contain other unrelated data. If you realize you made a mistake, change `DataWriteMode` to `Delete` and rerun.  