### PR TITLE
Add proxy support to the Cosmos Extension

### DIFF
--- a/Extensions/Cosmos/Cosmos.DataTransfer.CosmosExtension/CosmosExtensionServices.cs
+++ b/Extensions/Cosmos/Cosmos.DataTransfer.CosmosExtension/CosmosExtensionServices.cs
@@ -6,6 +6,7 @@ using System.Globalization;
 using System.Reflection;
 using Azure.Core;
 using System.Text.RegularExpressions;
+using System.Net;
 
 namespace Cosmos.DataTransfer.CosmosExtension
 {
@@ -31,6 +32,10 @@ namespace Cosmos.DataTransfer.CosmosExtension
                 EnableContentResponseOnWrite = false,
                 Serializer = cosmosSerializer,
             };
+
+            if (!string.IsNullOrEmpty(settings.WebProxy)){
+                clientOptions.WebProxy = new WebProxy(settings.WebProxy);
+            }
             
             CosmosClient? cosmosClient;
             if (settings.UseRbacAuth)

--- a/Extensions/Cosmos/Cosmos.DataTransfer.CosmosExtension/CosmosSettingsBase.cs
+++ b/Extensions/Cosmos/Cosmos.DataTransfer.CosmosExtension/CosmosSettingsBase.cs
@@ -11,7 +11,7 @@ namespace Cosmos.DataTransfer.CosmosExtension
         [Required]
         public string? Container { get; set; }
         public ConnectionMode ConnectionMode { get; set; } = ConnectionMode.Gateway;
-
+        public string? WebProxy { get; set; }
         public bool UseRbacAuth { get; set; }
         public string? AccountEndpoint { get; set; }
         public bool EnableInteractiveCredentials { get; set; } = true;


### PR DESCRIPTION
These changes expose the underlying cosmosclient's webproxy setting and allow you to define a proxy in cosmos source or sink settings.