### PR TITLE
Mongo Source CSFLE support and Cosmos NoSQL Always Encrypted support

### DIFF
--- a/Core/Cosmos.DataTransfer.Core/Cosmos.DataTransfer.Core.csproj
+++ b/Core/Cosmos.DataTransfer.Core/Cosmos.DataTransfer.Core.csproj
@@ -19,8 +19,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.36.0" />
-    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
+    <PackageReference Include="Azure.Core" Version="1.38.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />

--- a/Extensions/Cosmos/Cosmos.DataTransfer.CosmosExtension/Cosmos.DataTransfer.CosmosExtension.csproj
+++ b/Extensions/Cosmos/Cosmos.DataTransfer.CosmosExtension/Cosmos.DataTransfer.CosmosExtension.csproj
@@ -8,8 +8,10 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Azure.Identity" Version="1.10.3" />
+		<PackageReference Include="Azure.Identity" Version="1.11.4" />
+		<PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.6.0" />
 		<PackageReference Include="Microsoft.Azure.Cosmos" Version="3.34.0" />
+		<PackageReference Include="Microsoft.Azure.Cosmos.Encryption" Version="2.0.3" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />

--- a/Extensions/Cosmos/Cosmos.DataTransfer.CosmosExtension/CosmosDataSinkExtension.cs
+++ b/Extensions/Cosmos/Cosmos.DataTransfer.CosmosExtension/CosmosDataSinkExtension.cs
@@ -94,7 +94,7 @@ namespace Cosmos.DataTransfer.CosmosExtension
             }
 
             var convertedObjects = dataItems
-                .Select(di => di.BuildDynamicObjectTree(requireStringId: true, ignoreNullValues: settings.IgnoreNullValues, preserveMixedCaseIds: settings.PreserveMixedCaseIds))
+                .Select(di => di.BuildDynamicObjectTree(requireStringId: true, ignoreNullValues: settings.IgnoreNullValues, preserveMixedCaseIds: settings.PreserveMixedCaseIds, transformations: settings.Transformations))
                 .Where(o => o != null)
                 .OfType<ExpandoObject>();
             var batches = convertedObjects.Buffer(settings.BatchSize);

--- a/Extensions/Cosmos/Cosmos.DataTransfer.CosmosExtension/CosmosDataSinkExtension.cs
+++ b/Extensions/Cosmos/Cosmos.DataTransfer.CosmosExtension/CosmosDataSinkExtension.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Text;
 using Cosmos.DataTransfer.Interfaces;
 using Microsoft.Azure.Cosmos;
+using Microsoft.Azure.Cosmos.Encryption;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
@@ -28,7 +29,14 @@ namespace Cosmos.DataTransfer.CosmosExtension
             Container? container;
             if (settings.UseRbacAuth)
             {
-                container = client.GetContainer(settings.Database, settings.Container);
+                if (settings.InitClientEncryption)
+                {
+                    container = await client.GetContainer(settings.Database, settings.Container).InitializeEncryptionAsync();
+                }
+                else
+                {
+                    container = client.GetContainer(settings.Database, settings.Container);
+                }
             }
             else
             {

--- a/Extensions/Cosmos/Cosmos.DataTransfer.CosmosExtension/CosmosDataSourceExtension.cs
+++ b/Extensions/Cosmos/Cosmos.DataTransfer.CosmosExtension/CosmosDataSourceExtension.cs
@@ -2,6 +2,7 @@
 using System.Runtime.CompilerServices;
 using Cosmos.DataTransfer.Interfaces;
 using Microsoft.Azure.Cosmos;
+using Microsoft.Azure.Cosmos.Encryption;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 
@@ -19,8 +20,17 @@ namespace Cosmos.DataTransfer.CosmosExtension
 
             var client = CosmosExtensionServices.CreateClient(settings, DisplayName);
 
-            var container = client.GetContainer(settings.Database, settings.Container);
+            Container container;
             
+            if(settings.InitClientEncryption)
+            {
+                container = await client.GetContainer(settings.Database, settings.Container).InitializeEncryptionAsync();
+            }
+            else
+            {
+                container = client.GetContainer(settings.Database, settings.Container);
+            }
+
             await CosmosExtensionServices.VerifyContainerAccess(container, settings.Container, logger, cancellationToken);
 
             var requestOptions = new QueryRequestOptions();

--- a/Extensions/Cosmos/Cosmos.DataTransfer.CosmosExtension/CosmosExtensionServices.cs
+++ b/Extensions/Cosmos/Cosmos.DataTransfer.CosmosExtension/CosmosExtensionServices.cs
@@ -6,6 +6,8 @@ using System.Globalization;
 using System.Reflection;
 using Azure.Core;
 using System.Text.RegularExpressions;
+using Microsoft.Azure.Cosmos.Encryption;
+using Azure.Security.KeyVault.Keys.Cryptography;
 
 namespace Cosmos.DataTransfer.CosmosExtension
 {
@@ -36,7 +38,17 @@ namespace Cosmos.DataTransfer.CosmosExtension
             if (settings.UseRbacAuth)
             {
                 TokenCredential tokenCredential = new DefaultAzureCredential(includeInteractiveCredentials: settings.EnableInteractiveCredentials);
-                cosmosClient = new CosmosClient(settings.AccountEndpoint, tokenCredential, clientOptions);
+
+                if(settings.InitClientEncryption)
+                {
+                    var keyResolver = new KeyResolver(tokenCredential);
+                    cosmosClient = new CosmosClient(settings.AccountEndpoint, tokenCredential, clientOptions)
+                        .WithEncryption(keyResolver, KeyEncryptionKeyResolverName.AzureKeyVault);
+                }
+                else
+                {
+                    cosmosClient = new CosmosClient(settings.AccountEndpoint, tokenCredential, clientOptions);
+                }
             }
             else
             {

--- a/Extensions/Cosmos/Cosmos.DataTransfer.CosmosExtension/CosmosSettingsBase.cs
+++ b/Extensions/Cosmos/Cosmos.DataTransfer.CosmosExtension/CosmosSettingsBase.cs
@@ -15,6 +15,7 @@ namespace Cosmos.DataTransfer.CosmosExtension
         public bool UseRbacAuth { get; set; }
         public string? AccountEndpoint { get; set; }
         public bool EnableInteractiveCredentials { get; set; } = true;
+        public bool InitClientEncryption { get; set; } = false;
 
         public virtual IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {
@@ -25,6 +26,10 @@ namespace Cosmos.DataTransfer.CosmosExtension
             if (UseRbacAuth && string.IsNullOrEmpty(AccountEndpoint))
             {
                 yield return new ValidationResult("AccountEndpoint must be specified when UseRbacAuth is true", new[] { nameof(AccountEndpoint) });
+            }
+            if (!UseRbacAuth && InitClientEncryption)
+            {
+                yield return new ValidationResult("InitClientEncryption can only be used when UseRbacAuth is true", new[] { nameof(InitClientEncryption) });
             }
         }
     }

--- a/Extensions/Cosmos/Cosmos.DataTransfer.CosmosExtension/CosmosSinkSettings.cs
+++ b/Extensions/Cosmos/Cosmos.DataTransfer.CosmosExtension/CosmosSinkSettings.cs
@@ -18,6 +18,7 @@ namespace Cosmos.DataTransfer.CosmosExtension
         public DataWriteMode WriteMode { get; set; } = DataWriteMode.Insert;
         public bool IgnoreNullValues { get; set; } = false;
         public List<string>? PartitionKeyPaths { get; set; }
+        public Dictionary<string, DataItemTransformation>? Transformations { get; set; }
 
         public override IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
         {
@@ -58,6 +59,11 @@ namespace Cosmos.DataTransfer.CosmosExtension
             {
                 yield return new ValidationResult("PartitionKeyPath must be specified when WriteMode is set to InsertStream or UpsertStream", new[] { nameof(PartitionKeyPath), nameof(PartitionKeyPaths), nameof(WriteMode) });
             }
+
+            if (HasInvalidTransformations())
+            {
+                yield return new ValidationResult("Transformations must always specify SourceFieldName and either DestinationFieldName or DestinationFieldType", new[] { nameof(Transformations) });
+            }
         }
 
         private bool MissingPartitionKeys()
@@ -69,6 +75,12 @@ namespace Cosmos.DataTransfer.CosmosExtension
                 return false;
 
             return true;
+        }
+
+        private bool HasInvalidTransformations()
+        {
+            return Transformations != null && 
+                Transformations.Any(t => string.IsNullOrEmpty(t.Value.DestinationFieldName) && string.IsNullOrEmpty(t.Value.DestinationFieldTypeCode));
         }
     }
 }

--- a/Extensions/Cosmos/README.md
+++ b/Extensions/Cosmos/README.md
@@ -16,6 +16,14 @@ Source and sink settings also both require parameters to specify the data locati
 
 Source supports an optional `IncludeMetadataFields` parameter (`false` by default) to enable inclusion of built-in Cosmos fields prefixed with `"_"`, for example `"_etag"` and `"_ts"`. An optional PartitionKeyValue setting allows for filtering to a single partition. The optional Query setting allows further filtering using a Cosmos SQL statement.
 
+### Always Encrypted
+
+Source and Sink support Always Encrypted as an optional parameter. When `InitClientEncryption` is set to `true`, the extension will initialize the Cosmos client with the Always Encrypted feature enabled. This allows for the use of encrypted fields in the Cosmos DB container. The extension will automatically decrypt the fields when reading from the source and encrypt the fields when writing to the sink. 
+</br>
+The extension will also automatically handle the encryption keys and encryption policy for the client, but it requires `UseRbacAuth` to be set to `true` and the user to have the necessary permissions to access the key vault.
+</br>
+> **Note**: To use Always Encrypted, Cosmos DB container must be pre-configured with the necessary encryption policy and the user must have the necessary permissions to access the key vault.
+
 ### Source
 
 ```json

--- a/Extensions/Cosmos/README.md
+++ b/Extensions/Cosmos/README.md
@@ -40,7 +40,8 @@ Or with RBAC:
     "Container":"myContainer",
     "IncludeMetadataFields": false,
     "PartitionKeyValue":"123",
-    "Query":"SELECT * FROM c WHERE c.category='event'"
+    "Query":"SELECT * FROM c WHERE c.category='event'",
+    "InitClientEncryption": false
 }
 ```
 
@@ -65,6 +66,7 @@ Sink requires an additional `PartitionKeyPath` parameter which is used when crea
     "PreserveMixedCaseIds": false,
     "IgnoreNullValues": false,
     "IsServerlessAccount": false,
-    "UseSharedThroughput": false
+    "UseSharedThroughput": false,
+    "InitClientEncryption": false
 }
 ```

--- a/Extensions/Mongo/Cosmos.DataTransfer.MongoExtension/MongoDataSourceExtension.cs
+++ b/Extensions/Mongo/Cosmos.DataTransfer.MongoExtension/MongoDataSourceExtension.cs
@@ -40,7 +40,7 @@ internal class MongoDataSourceExtension : IDataSourceExtensionWithSettings
         logger.LogInformation("Reading collection '{Collection}'", collectionName);
         var collection = context.GetRepository<BsonDocument>(collectionName);
         int itemCount = 0;
-        foreach (var record in collection.AsQueryable())
+        foreach (var record in await Task.Run(() => collection.AsQueryable()))
         {
             yield return new MongoDataItem(record);
             itemCount++;

--- a/Extensions/Mongo/Cosmos.DataTransfer.MongoExtension/MongoDataSourceExtension.cs
+++ b/Extensions/Mongo/Cosmos.DataTransfer.MongoExtension/MongoDataSourceExtension.cs
@@ -19,7 +19,7 @@ internal class MongoDataSourceExtension : IDataSourceExtensionWithSettings
 
         if (!string.IsNullOrEmpty(settings.ConnectionString) && !string.IsNullOrEmpty(settings.DatabaseName))
         {
-            var context = new Context(settings.ConnectionString, settings.DatabaseName);
+            var context = new Context(settings.ConnectionString, settings.DatabaseName, settings.KeyVaultNamespace, settings.KMSProviders);
 
             var collectionNames = !string.IsNullOrEmpty(settings.Collection)
                 ? new List<string> { settings.Collection }

--- a/Extensions/Mongo/Cosmos.DataTransfer.MongoExtension/Settings/MongoSourceSettings.cs
+++ b/Extensions/Mongo/Cosmos.DataTransfer.MongoExtension/Settings/MongoSourceSettings.cs
@@ -1,5 +1,12 @@
-﻿namespace Cosmos.DataTransfer.MongoExtension.Settings;
+﻿using Cosmos.DataTransfer.Interfaces.Manifest;
+
+namespace Cosmos.DataTransfer.MongoExtension.Settings;
 public class MongoSourceSettings : MongoBaseSettings
 {
     public string? Collection { get; set; }
+
+    [SensitiveValue]
+    public Dictionary<string, IReadOnlyDictionary<string, object>>? KMSProviders { get; set; }
+
+    public string? KeyVaultNamespace { get; set; }
 }

--- a/Extensions/Mongo/README.md
+++ b/Extensions/Mongo/README.md
@@ -23,7 +23,7 @@ Source and sink settings require both `ConnectionString` and `DatabaseName` para
 ```json
 {
     "ConnectionString": "",
-    "DatabaseName: "",
+    "DatabaseName": "",
     "Collection": ""
 }
 ```
@@ -36,9 +36,36 @@ The MongoDB Vector extension is a Sink only extension that builds on the MongoDB
 
 ## Settings
 
-The settings are based on the MongoDB extension settings with additional parameters for generating embeddings.
+### Additional Source Settings
+
+If using CSFLE (Client Side Field Level Encryption), source sink supports autodecryption providing the following parameters:
+
+- `KeyVaultNamespace`: Database and collection holding the Key Vault and Keys details. Format: `database.collection`
+- `KMSProviders`: Key Management Service providers for the Key Vault. For Azure Key Vault support, the following parameters are required:
+  - `tenantId`: The Azure Active Directory tenant ID
+  - `clientId`: The Azure Active Directory application client ID
+  - `clientSecret`: The Azure Active Directory application client secret
+
+```json
+{
+    "ConnectionString": "",
+    "DatabaseName: "",
+    "Collection": "",
+    "KeyVaultNamespace": "",
+    "KMSProviders": {
+		"azure": {
+			"tenantId": "",
+			"clientId": "",
+			"clientSecret": ""
+		}
+	}
+}
+```
+
 
 ### Additional Sink Settings
+
+The settings are based on the MongoDB extension settings with additional parameters for generating embeddings.
 
 The sink settings require the following additional parameters:
 

--- a/Extensions/Mongo/README.md
+++ b/Extensions/Mongo/README.md
@@ -13,7 +13,7 @@ Source and sink settings require both `ConnectionString` and `DatabaseName` para
 ```json
 {
     "ConnectionString": "",
-    "DatabaseName: "",
+    "DatabaseName": "",
     "Collection": ""
 }
 ```

--- a/Extensions/Mongo/README.md
+++ b/Extensions/Mongo/README.md
@@ -49,7 +49,7 @@ If using CSFLE (Client Side Field Level Encryption), source sink supports autode
 ```json
 {
     "ConnectionString": "",
-    "DatabaseName: "",
+    "DatabaseName": "",
     "Collection": "",
     "KeyVaultNamespace": "",
     "KMSProviders": {
@@ -79,7 +79,7 @@ The sink settings require the following additional parameters:
 ```json
 {
     "ConnectionString": "",
-    "DatabaseName: "",
+    "DatabaseName": "",
     "Collection": "",
     "BatchSize: 100,
     "GenerateEmbedding": true | false

--- a/Interfaces/Cosmos.DataTransfer.Interfaces/DataItemTransformation.cs
+++ b/Interfaces/Cosmos.DataTransfer.Interfaces/DataItemTransformation.cs
@@ -1,0 +1,8 @@
+﻿namespace Cosmos.DataTransfer.Interfaces
+{
+    public class DataItemTransformation
+    {
+        public string? DestinationFieldName { get; set; }
+        public string? DestinationFieldTypeCode { get; set; }
+    }
+}


### PR DESCRIPTION
- Adding support for MongoDB Client Side Field Level Encryption: auto decrypt in Mongo source
- Adding support for Cosmos NoSQL Always Encrypted
- Adding basic transformations (destination field name and type). Can be useful to convert _id to id and non-string shard key to Cosmos NoSQL.
- Updating some dependencies due to existing vulnerability