### PR TITLE
Fix for release builds and consolidate NuGet packages 

### DIFF
--- a/Core/Cosmos.DataTransfer.Core/Cosmos.DataTransfer.Core.csproj
+++ b/Core/Cosmos.DataTransfer.Core/Cosmos.DataTransfer.Core.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="System.CommandLine.Hosting" Version="0.4.0-alpha.22272.1" />
-    <PackageReference Include="System.ComponentModel.Composition" Version="6.0.0" />
+    <PackageReference Include="System.ComponentModel.Composition" Version="7.0.0" />
     <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.0" />
   </ItemGroup>
 

--- a/Core/Cosmos.DataTransfer.Core/Properties/launchSettings.json
+++ b/Core/Cosmos.DataTransfer.Core/Properties/launchSettings.json
@@ -1,7 +1,8 @@
 {
   "profiles": {
     "Cosmos.DataTransfer.Core": {
-      "commandName": "Project"
+      "commandName": "Project",
+      "commandLineArgs": ""
     },
     "JSON->Cosmos": {
       "commandName": "Project",
@@ -9,7 +10,7 @@
     },
     "Cosmos->JSON": {
       "commandName": "Project",
-      "commandLineArgs": "--source cosmos-nosql --sink JSON-AzureBlob --settings=c:\\temp\\Cosmos-JsonSettings4.json"
+      "commandLineArgs": "--source cosmos-nosql --sink json --settings=c:\\temp\\Cosmos-JsonSettings.json"
     },
     "SqlServer->Cosmos": {
       "commandName": "Project",

--- a/Core/Cosmos.DataTransfer.Core/Properties/launchSettings.json
+++ b/Core/Cosmos.DataTransfer.Core/Properties/launchSettings.json
@@ -1,8 +1,7 @@
 {
   "profiles": {
     "Cosmos.DataTransfer.Core": {
-      "commandName": "Project",
-      "commandLineArgs": ""
+      "commandName": "Project"
     },
     "JSON->Cosmos": {
       "commandName": "Project",
@@ -10,7 +9,7 @@
     },
     "Cosmos->JSON": {
       "commandName": "Project",
-      "commandLineArgs": "--source cosmos-nosql --sink json --settings=c:\\temp\\Cosmos-JsonSettings.json"
+      "commandLineArgs": "--source cosmos-nosql --sink JSON-AzureBlob --settings=c:\\temp\\Cosmos-JsonSettings4.json"
     },
     "SqlServer->Cosmos": {
       "commandName": "Project",

--- a/Extensions/AzureTableAPI/Cosmos.DataTransfer.AzureTableAPIExtension.UnitTests/Cosmos.DataTransfer.AzureTableAPIExtension.UnitTests.csproj
+++ b/Extensions/AzureTableAPI/Cosmos.DataTransfer.AzureTableAPIExtension.UnitTests/Cosmos.DataTransfer.AzureTableAPIExtension.UnitTests.csproj
@@ -10,9 +10,9 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Data.Tables" Version="12.6.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="coverlet.collector" Version="3.1.2" />
   </ItemGroup>
 

--- a/Extensions/AzureTableAPI/Cosmos.DataTransfer.AzureTableAPIExtension/Cosmos.DataTransfer.AzureTableAPIExtension.csproj
+++ b/Extensions/AzureTableAPI/Cosmos.DataTransfer.AzureTableAPIExtension/Cosmos.DataTransfer.AzureTableAPIExtension.csproj
@@ -10,7 +10,7 @@
 	<ItemGroup>
 		<PackageReference Include="Azure.Data.Tables" Version="12.6.1" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
-		<PackageReference Include="System.ComponentModel.Composition" Version="6.0.0" />
+		<PackageReference Include="System.ComponentModel.Composition" Version="7.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Extensions/CognitiveSearch/Cosmos.DataTransfer.CognitiveSearchExtension.UnitTests/Cosmos.DataTransfer.CognitiveSearchExtension.UnitTests.csproj
+++ b/Extensions/CognitiveSearch/Cosmos.DataTransfer.CognitiveSearchExtension.UnitTests/Cosmos.DataTransfer.CognitiveSearchExtension.UnitTests.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="coverlet.collector" Version="3.1.2" />
   </ItemGroup>
 

--- a/Extensions/CognitiveSearch/Cosmos.DataTransfer.CognitiveSearchExtension/Cosmos.DataTransfer.CognitiveSearchExtension.csproj
+++ b/Extensions/CognitiveSearch/Cosmos.DataTransfer.CognitiveSearchExtension/Cosmos.DataTransfer.CognitiveSearchExtension.csproj
@@ -10,7 +10,7 @@
 	<ItemGroup>
 		<PackageReference Include="Azure.Search.Documents" Version="11.4.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
-		<PackageReference Include="System.ComponentModel.Composition" Version="6.0.0" />
+		<PackageReference Include="System.ComponentModel.Composition" Version="7.0.0" />
 		<PackageReference Include="System.Interactive.Async" Version="6.0.1" />
 		<PackageReference Include="System.Linq.Async" Version="6.0.1" />
 	</ItemGroup>

--- a/Extensions/Cosmos/Cosmos.DataTransfer.CosmosExtension.UnitTests/Cosmos.DataTransfer.CosmosExtension.UnitTests.csproj
+++ b/Extensions/Cosmos/Cosmos.DataTransfer.CosmosExtension.UnitTests/Cosmos.DataTransfer.CosmosExtension.UnitTests.csproj
@@ -10,9 +10,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="coverlet.collector" Version="3.1.2" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>

--- a/Extensions/Cosmos/Cosmos.DataTransfer.CosmosExtension/Cosmos.DataTransfer.CosmosExtension.csproj
+++ b/Extensions/Cosmos/Cosmos.DataTransfer.CosmosExtension/Cosmos.DataTransfer.CosmosExtension.csproj
@@ -16,7 +16,7 @@
 		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
 		<PackageReference Include="Polly" Version="7.2.3" />
-		<PackageReference Include="System.ComponentModel.Composition" Version="6.0.0" />
+		<PackageReference Include="System.ComponentModel.Composition" Version="7.0.0" />
 		<PackageReference Include="System.Interactive.Async" Version="6.0.1" />
 		<PackageReference Include="System.Linq.Async" Version="6.0.1" />
 	</ItemGroup>

--- a/Extensions/Csv/Cosmos.DataTransfer.CsvExtension.UnitTests/Cosmos.DataTransfer.CsvExtension.UnitTests.csproj
+++ b/Extensions/Csv/Cosmos.DataTransfer.CsvExtension.UnitTests/Cosmos.DataTransfer.CsvExtension.UnitTests.csproj
@@ -9,9 +9,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="coverlet.collector" Version="3.1.2" />
   </ItemGroup>
 

--- a/Extensions/Csv/Cosmos.DataTransfer.CsvExtension/Cosmos.DataTransfer.CsvExtension.csproj
+++ b/Extensions/Csv/Cosmos.DataTransfer.CsvExtension/Cosmos.DataTransfer.CsvExtension.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="CsvHelper" Version="30.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
-    <PackageReference Include="System.ComponentModel.Composition" Version="6.0.0" />
+    <PackageReference Include="System.ComponentModel.Composition" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Extensions/Json/Cosmos.DataTransfer.JsonExtension.UnitTests/Cosmos.DataTransfer.JsonExtension.UnitTests.csproj
+++ b/Extensions/Json/Cosmos.DataTransfer.JsonExtension.UnitTests/Cosmos.DataTransfer.JsonExtension.UnitTests.csproj
@@ -10,9 +10,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="coverlet.collector" Version="3.1.2" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>

--- a/Extensions/Json/Cosmos.DataTransfer.JsonExtension/Cosmos.DataTransfer.JsonExtension.csproj
+++ b/Extensions/Json/Cosmos.DataTransfer.JsonExtension/Cosmos.DataTransfer.JsonExtension.csproj
@@ -9,7 +9,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
-		<PackageReference Include="System.ComponentModel.Composition" Version="6.0.0" />
+		<PackageReference Include="System.ComponentModel.Composition" Version="7.0.0" />
 		<PackageReference Include="System.Linq.Async" Version="6.0.1" />
 	</ItemGroup>
 

--- a/Extensions/Mongo/Cosmos.DataTransfer.MongoExtension/Cosmos.DataTransfer.MongoExtension.csproj
+++ b/Extensions/Mongo/Cosmos.DataTransfer.MongoExtension/Cosmos.DataTransfer.MongoExtension.csproj
@@ -10,7 +10,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
 		<PackageReference Include="MongoDB.Driver" Version="2.19.1" />
-		<PackageReference Include="System.ComponentModel.Composition" Version="6.0.0" />
+		<PackageReference Include="System.ComponentModel.Composition" Version="7.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Extensions/Mongo/Cosmos.DataTransfer.MongoVectorExtension/Cosmos.DataTransfer.MongoVectorExtension.csproj
+++ b/Extensions/Mongo/Cosmos.DataTransfer.MongoVectorExtension/Cosmos.DataTransfer.MongoVectorExtension.csproj
@@ -11,7 +11,7 @@
 		<PackageReference Include="Azure.AI.OpenAI" Version="1.0.0-beta.12" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
 		<PackageReference Include="MongoDB.Driver" Version="2.19.1" />
-		<PackageReference Include="System.ComponentModel.Composition" Version="6.0.0" />
+		<PackageReference Include="System.ComponentModel.Composition" Version="7.0.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Extensions/SqlServer/Cosmos.DataTransfer.SqlServerExtension.UnitTests/Cosmos.DataTransfer.SqlServerExtension.UnitTests.csproj
+++ b/Extensions/SqlServer/Cosmos.DataTransfer.SqlServerExtension.UnitTests/Cosmos.DataTransfer.SqlServerExtension.UnitTests.csproj
@@ -10,9 +10,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.8" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.8" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="coverlet.collector" Version="3.1.2" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>

--- a/Extensions/SqlServer/Cosmos.DataTransfer.SqlServerExtension/Cosmos.DataTransfer.SqlServerExtension.csproj
+++ b/Extensions/SqlServer/Cosmos.DataTransfer.SqlServerExtension/Cosmos.DataTransfer.SqlServerExtension.csproj
@@ -8,7 +8,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
+		<PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.2" />
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />

--- a/Extensions/SqlServer/Cosmos.DataTransfer.SqlServerExtension/Cosmos.DataTransfer.SqlServerExtension.csproj
+++ b/Extensions/SqlServer/Cosmos.DataTransfer.SqlServerExtension/Cosmos.DataTransfer.SqlServerExtension.csproj
@@ -12,7 +12,7 @@
 		<PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
-		<PackageReference Include="System.ComponentModel.Composition" Version="6.0.0" />
+		<PackageReference Include="System.ComponentModel.Composition" Version="7.0.0" />
 		<PackageReference Include="System.Interactive.Async" Version="6.0.1" />
 		<PackageReference Include="System.Linq.Async" Version="6.0.1" />
 	</ItemGroup>

--- a/Interfaces/Cosmos.DataTransfer.Interfaces/Cosmos.DataTransfer.Interfaces.csproj
+++ b/Interfaces/Cosmos.DataTransfer.Interfaces/Cosmos.DataTransfer.Interfaces.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This change address issue #146 and consolidates all NuGet packages to the same versions.

Changes:
1.  Cosmos.DataTransfer.Interfaces.csproj referenced version 6.0.0.0 of Microsoft.Extensions.Logging.Abstractions, which was causing the load failure. Updating to version 8.0.0.0 resolves the issue.
2. Visual Studio package manager for the solution suggested a number of NuGet packages that could be consolidated. This change gets everything on the same version.

**How tested:**
1. Tested successful source: cosmos-nosql -> sink: Json-AzureBlob via command line
2. Ran GitHub Action for generating packages: https://github.com/philnach/data-migration-desktop-tool/actions/runs/11045214931
3. Verified windows-package runs successfully without error from command line
4. Ran unit tests and confirmed the all passed: https://github.com/philnach/data-migration-desktop-tool/actions/runs/11045455482