### PR TITLE
Added DataType in SQL Column Mapping 

### DIFF
--- a/Extensions/SqlServer/Cosmos.DataTransfer.SqlServerExtension/ColumnMapping.cs
+++ b/Extensions/SqlServer/Cosmos.DataTransfer.SqlServerExtension/ColumnMapping.cs
@@ -9,6 +9,7 @@ namespace Cosmos.DataTransfer.SqlServerExtension
         public string? SourceFieldName { get; set; }
         public bool AllowNull { get; set; } = true;
         public object? DefaultValue { get; set; }
+        public string? DataType { get; set; }
 
         public string? GetFieldName()
         {

--- a/Extensions/SqlServer/Cosmos.DataTransfer.SqlServerExtension/ColumnMapping.cs
+++ b/Extensions/SqlServer/Cosmos.DataTransfer.SqlServerExtension/ColumnMapping.cs
@@ -8,8 +8,8 @@ namespace Cosmos.DataTransfer.SqlServerExtension
         public string? ColumnName { get; set; }
         public string? SourceFieldName { get; set; }
         public bool AllowNull { get; set; } = true;
-        public object? DefaultValue { get; set; }
-        public string? DataType { get; set; }
+        public object? DefaultValue { get; set; } 
+        public string? DataType { get; set; } = "System.String";
 
         public string? GetFieldName()
         {

--- a/Extensions/SqlServer/Cosmos.DataTransfer.SqlServerExtension/SqlServerDataSinkExtension.cs
+++ b/Extensions/SqlServer/Cosmos.DataTransfer.SqlServerExtension/SqlServerDataSinkExtension.cs
@@ -31,7 +31,7 @@ namespace Cosmos.DataTransfer.SqlServerExtension
                     var dataColumns = new Dictionary<ColumnMapping, DataColumn>();
                     foreach (ColumnMapping columnMapping in settings.ColumnMappings)
                     {
-                        DataColumn dbColumn = new DataColumn(columnMapping.ColumnName);
+                        DataColumn dbColumn = new DataColumn(columnMapping.ColumnName, Type.GetType(columnMapping.DataType));
                         dataColumns.Add(columnMapping, dbColumn);
                         bulkCopy.ColumnMappings.Add(new SqlBulkCopyColumnMapping(dbColumn.ColumnName, dbColumn.ColumnName));
                     }
@@ -60,7 +60,7 @@ namespace Cosmos.DataTransfer.SqlServerExtension
                                     {
                                         value = item.GetValue(sourceField);
                                     }
-                                    
+
                                     if (value != null || mapping.AllowNull)
                                     {
                                         if (value is IDataItem child)

--- a/Extensions/SqlServer/Cosmos.DataTransfer.SqlServerExtension/SqlServerDataSinkExtension.cs
+++ b/Extensions/SqlServer/Cosmos.DataTransfer.SqlServerExtension/SqlServerDataSinkExtension.cs
@@ -31,11 +31,13 @@ namespace Cosmos.DataTransfer.SqlServerExtension
                     var dataColumns = new Dictionary<ColumnMapping, DataColumn>();
                     foreach (ColumnMapping columnMapping in settings.ColumnMappings)
                     {
-                        DataColumn dbColumn = new DataColumn(columnMapping.ColumnName, Type.GetType(columnMapping.DataType));
+                        Type type = Type.GetType(columnMapping.DataType ?? "System.String")!;
+                        DataColumn dbColumn = new DataColumn(columnMapping.ColumnName, type);
                         dataColumns.Add(columnMapping, dbColumn);
                         bulkCopy.ColumnMappings.Add(new SqlBulkCopyColumnMapping(dbColumn.ColumnName, dbColumn.ColumnName));
                     }
 
+                    
                     var dataTable = new DataTable();
                     dataTable.Columns.AddRange(dataColumns.Values.ToArray());
 

--- a/Extensions/SqlServer/README.md
+++ b/Extensions/SqlServer/README.md
@@ -23,7 +23,9 @@ Sink settings require a `TableName` to define where to insert data and an array 
 - `SourceFieldName`: This should be set in cases where the source data uses a different name than the SQL column. Column name to source field mapping defaults to using the `ColumnName` for both sides and is case-insensitive so it is not necessary to specify this parameter for mappings like `"id"` -> `"Id"`.
 - `AllowNull`: Depending on the table schema you may need to force values to be set for columns when no value is present in the source. If this is set to `false` this column will use the `DefaultValue` for any records missing a source value. Defaults to `true`.
 - `DefaultValue`: Value to be used in place of missing or null source fields. This parameter is ignored unless `AllowNull` is set to `false` for this column.
+- `DataType`: This setting specify the DataType of the column, default will be String: please refer documentation. https://learn.microsoft.com/sql/relational-databases/clr-integration-database-objects-types-net-framework/mapping-clr-parameter-data?view=sql-server-ver16&redirectedfrom=MSDN&tabs=csharp
 
+- 
 Sink settings also include an optional `BatchSize` parameter to specify the count of records to accumulate before bulk inserting, default value is 1000.
 
 ### Sink
@@ -50,6 +52,7 @@ Sink settings also include an optional `BatchSize` parameter to specify the coun
             "ColumnName": "IsSet",
             "AllowNull": false,
             "DefaultValue": false
+            "DataType": "System.Boolean"
         }
     ],
     "BatchSize": 1000


### PR DESCRIPTION
Added DataType in SQL Column Mapping class to specify data type for each column. as exiting code doesn't support datatypes other than string. this will convenient for a user to specify column type in sink settings.