### PR TITLE
Update Upload-Artifact to v4 to fix builds and unblock approved PR's

### DIFF
--- a/.github/actions/build-with-plugins/action.yml
+++ b/.github/actions/build-with-plugins/action.yml
@@ -167,7 +167,7 @@ runs:
         -p:PublishTrimmed=false \
         -p:Version=${{ inputs.build-version }}
     - name: Upload package
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.platform }}-package
         path: ${{ inputs.platform-short }}/


### PR DESCRIPTION
Fixes #167 by updating upload-artifact action from 'v3' to 'v4'

**How verified:**
Confirmed build succeeds and artifacts exist from fork: https://github.com/philnach/data-migration-desktop-tool/actions/runs/13084802722
![image](https://github.com/user-attachments/assets/6850551b-580a-4e5e-8c3a-4a84176d1f49)
