### PR TITLE
Native ARM64 builds and release updates

### DIFF
--- a/.github/actions/build-with-plugins/action.yml
+++ b/.github/actions/build-with-plugins/action.yml
@@ -171,7 +171,7 @@ runs:
       shell: bash
       run: |
         ls -la ${{ inputs.runtime }}
-        tar -czvf ${{ inputs.runtime }}/${{ inputs.runtime }}-package.tar.gz -C ${{ inputs.runtime }} . -v
+        tar -czvf ${{ inputs.runtime }}-package/${{ inputs.runtime }}-package.tar.gz -C ${{ inputs.runtime }}/ . -v
     - name: Upload package
       if: startsWith(inputs.platform, 'linux') != true
       uses: actions/upload-artifact@v4
@@ -183,4 +183,4 @@ runs:
       uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.runtime }}-package-tar
-        path: ${{ inputs.runtime }}/${{ inputs.runtime }}-package.tar.gz
+        path: ${{ inputs.runtime }}-package/${{ inputs.runtime }}-package.tar.gz

--- a/.github/actions/build-with-plugins/action.yml
+++ b/.github/actions/build-with-plugins/action.yml
@@ -166,25 +166,8 @@ runs:
         -p:PublishReadyToRun=false \
         -p:PublishTrimmed=false \
         -p:Version=${{ inputs.build-version }}
-    - name: Create tar archive
-      if: startsWith(inputs.platform, 'linux')
-      shell: bash
-      run: |
-        # check if the directory exists
-        ls -la ${{ inputs.runtime }}
-        # create a directory for the tar file
-        mkdir -p ${{ inputs.runtime }}-package
-        # create the tar file
-        tar -czvf ${{ inputs.runtime }}-package/${{ inputs.runtime }}-package.tar.gz -C ${{ inputs.runtime }}/ . -v
     - name: Upload package
-      if: startsWith(inputs.platform, 'linux') != true
       uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.runtime }}-package
         path: ${{ inputs.runtime }}/
-    - name: Upload tar archive
-      if: startsWith(inputs.platform, 'linux')
-      uses: actions/upload-artifact@v4
-      with:
-        name: ${{ inputs.runtime }}-package-tar
-        path: ${{ inputs.runtime }}-package/${{ inputs.runtime }}-package.tar.gz

--- a/.github/actions/build-with-plugins/action.yml
+++ b/.github/actions/build-with-plugins/action.yml
@@ -171,7 +171,7 @@ runs:
       shell: bash
       run: |
         ls -la ${{ inputs.runtime }}
-        tar -czvf ${{ inputs.runtime }}-package.tar.gz -C ${{ inputs.runtime }}
+        tar -czvf ${{ inputs.runtime }}-package.tar.gz -C ${{ inputs.runtime }}/
     - name: Upload package
       if: startsWith(inputs.platform, 'linux') != true
       uses: actions/upload-artifact@v4

--- a/.github/actions/build-with-plugins/action.yml
+++ b/.github/actions/build-with-plugins/action.yml
@@ -172,7 +172,7 @@ runs:
       run: |
         tar -czvf ${{ inputs.runtime }}-package.tar.gz -C ${{ inputs.runtime }}
     - name: Upload package
-      if: "!startsWith(inputs.platform, 'linux')
+      if: !(startsWith(inputs.platform, 'linux'))
       uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.runtime }}-package

--- a/.github/actions/build-with-plugins/action.yml
+++ b/.github/actions/build-with-plugins/action.yml
@@ -170,4 +170,4 @@ runs:
       uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.runtime }}-package
-        path: ${{ inputs.runtime }}/
+        path: ${{ inputs.runtime }}

--- a/.github/actions/build-with-plugins/action.yml
+++ b/.github/actions/build-with-plugins/action.yml
@@ -169,5 +169,5 @@ runs:
     - name: Upload package
       uses: actions/upload-artifact@v4
       with:
-        name: ${{ inputs.platform }}-package
+        name: ${{ inputs.runtime }}-package
         path: ${{ inputs.runtime }}/

--- a/.github/actions/build-with-plugins/action.yml
+++ b/.github/actions/build-with-plugins/action.yml
@@ -170,6 +170,7 @@ runs:
       if: startsWith(inputs.platform, 'linux')
       shell: bash
       run: |
+        ls -la ${{ inputs.runtime }}
         tar -czvf ${{ inputs.runtime }}-package.tar.gz -C ${{ inputs.runtime }}
     - name: Upload package
       if: startsWith(inputs.platform, 'linux') != true

--- a/.github/actions/build-with-plugins/action.yml
+++ b/.github/actions/build-with-plugins/action.yml
@@ -171,7 +171,7 @@ runs:
       shell: bash
       run: |
         ls -la ${{ inputs.runtime }}
-        tar -czvf ${{ inputs.runtime }}-package.tar.gz -C ${{ inputs.runtime }}/
+        tar -czvf ${{ inputs.runtime }}-package.tar.gz -C ${{ inputs.runtime }}/ -v
     - name: Upload package
       if: startsWith(inputs.platform, 'linux') != true
       uses: actions/upload-artifact@v4

--- a/.github/actions/build-with-plugins/action.yml
+++ b/.github/actions/build-with-plugins/action.yml
@@ -166,8 +166,20 @@ runs:
         -p:PublishReadyToRun=false \
         -p:PublishTrimmed=false \
         -p:Version=${{ inputs.build-version }}
+    - name: Create tar archive
+      if: startsWith(inputs.platform, 'linux')
+      shell: bash
+      run: |
+        tar -czvf ${{ inputs.runtime }}-package.tar.gz -C ${{ inputs.runtime }}
     - name: Upload package
+      if: !startsWith(inputs.platform, 'linux')
       uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.runtime }}-package
         path: ${{ inputs.runtime }}/
+    - name: Upload tar archive
+      if: startsWith(inputs.platform, 'linux')
+      uses: actions/upload-artifact@v4
+      with:
+        name: ${{ inputs.runtime }}-package-tar
+        path: ${{ inputs.runtime }}-package.tar.gz

--- a/.github/actions/build-with-plugins/action.yml
+++ b/.github/actions/build-with-plugins/action.yml
@@ -172,7 +172,7 @@ runs:
       run: |
         tar -czvf ${{ inputs.runtime }}-package.tar.gz -C ${{ inputs.runtime }}
     - name: Upload package
-      if: !(startsWith(inputs.platform, 'linux'))
+      if: startsWith(inputs.platform, 'linux') != true
       uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.runtime }}-package

--- a/.github/actions/build-with-plugins/action.yml
+++ b/.github/actions/build-with-plugins/action.yml
@@ -171,7 +171,7 @@ runs:
       shell: bash
       run: |
         ls -la ${{ inputs.runtime }}
-        tar -czvf ${{ inputs.runtime }}-package.tar.gz -C ${{ inputs.runtime }}/ -v
+        tar -czvf ${{ inputs.runtime }}/${{ inputs.runtime }}-package.tar.gz -C ${{ inputs.runtime }} -v
     - name: Upload package
       if: startsWith(inputs.platform, 'linux') != true
       uses: actions/upload-artifact@v4
@@ -183,4 +183,4 @@ runs:
       uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.runtime }}-package-tar
-        path: ${{ inputs.runtime }}-package.tar.gz
+        path: ${{ inputs.runtime }}/${{ inputs.runtime }}-package.tar.gz

--- a/.github/actions/build-with-plugins/action.yml
+++ b/.github/actions/build-with-plugins/action.yml
@@ -170,7 +170,11 @@ runs:
       if: startsWith(inputs.platform, 'linux')
       shell: bash
       run: |
+        # check if the directory exists
         ls -la ${{ inputs.runtime }}
+        # create a directory for the tar file
+        mkdir -p ${{ inputs.runtime }}-package
+        # create the tar file
         tar -czvf ${{ inputs.runtime }}-package/${{ inputs.runtime }}-package.tar.gz -C ${{ inputs.runtime }}/ . -v
     - name: Upload package
       if: startsWith(inputs.platform, 'linux') != true

--- a/.github/actions/build-with-plugins/action.yml
+++ b/.github/actions/build-with-plugins/action.yml
@@ -172,7 +172,7 @@ runs:
       run: |
         tar -czvf ${{ inputs.runtime }}-package.tar.gz -C ${{ inputs.runtime }}
     - name: Upload package
-      if: !startsWith(inputs.platform, 'linux')
+      if: "!startsWith(inputs.platform, 'linux')
       uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.runtime }}-package

--- a/.github/actions/build-with-plugins/action.yml
+++ b/.github/actions/build-with-plugins/action.yml
@@ -171,7 +171,7 @@ runs:
       shell: bash
       run: |
         ls -la ${{ inputs.runtime }}
-        tar -czvf ${{ inputs.runtime }}/${{ inputs.runtime }}-package.tar.gz -C ${{ inputs.runtime }} -v
+        tar -czvf ${{ inputs.runtime }}/${{ inputs.runtime }}-package.tar.gz -C ${{ inputs.runtime }} . -v
     - name: Upload package
       if: startsWith(inputs.platform, 'linux') != true
       uses: actions/upload-artifact@v4

--- a/.github/actions/build-with-plugins/action.yml
+++ b/.github/actions/build-with-plugins/action.yml
@@ -22,7 +22,7 @@ runs:
         dotnet publish \
         Core/Cosmos.DataTransfer.Core/Cosmos.DataTransfer.Core.csproj \
         --configuration Release \
-        --output ${{ inputs.platform-short }} \
+        --output ${{ inputs.runtime }} \
         --self-contained true \
         --runtime ${{ inputs.runtime }} \
         -p:PublishSingleFile=true \
@@ -37,7 +37,7 @@ runs:
         dotnet publish \
         Extensions/Cosmos/Cosmos.DataTransfer.CosmosExtension/Cosmos.DataTransfer.CosmosExtension.csproj \
         --configuration Release \
-        --output ${{ inputs.platform-short }}/Extensions \
+        --output ${{ inputs.runtime }}/Extensions \
         --self-contained false \
         --runtime ${{ inputs.runtime }} \
         -p:PublishSingleFile=false \
@@ -52,7 +52,7 @@ runs:
         dotnet publish \
         Extensions/Json/Cosmos.DataTransfer.JsonExtension/Cosmos.DataTransfer.JsonExtension.csproj \
         --configuration Release \
-        --output ${{ inputs.platform-short }}/Extensions \
+        --output ${{ inputs.runtime }}/Extensions \
         --self-contained false \
         --runtime ${{ inputs.runtime }} \
         -p:PublishSingleFile=false \
@@ -67,7 +67,7 @@ runs:
         dotnet publish \
         Extensions/AzureTableAPI/Cosmos.DataTransfer.AzureTableAPIExtension/Cosmos.DataTransfer.AzureTableAPIExtension.csproj \
         --configuration Release \
-        --output ${{ inputs.platform-short }}/Extensions \
+        --output ${{ inputs.runtime }}/Extensions \
         --self-contained false \
         --runtime ${{ inputs.runtime }} \
         -p:PublishSingleFile=false \
@@ -82,7 +82,7 @@ runs:
         dotnet publish \
         Extensions/Mongo/Cosmos.DataTransfer.MongoExtension/Cosmos.DataTransfer.MongoExtension.csproj \
         --configuration Release \
-        --output ${{ inputs.platform-short }}/Extensions \
+        --output ${{ inputs.runtime }}/Extensions \
         --self-contained false \
         --runtime ${{ inputs.runtime }} \
         -p:PublishSingleFile=false \
@@ -97,7 +97,7 @@ runs:
         dotnet publish \
         Extensions/SqlServer/Cosmos.DataTransfer.SqlServerExtension/Cosmos.DataTransfer.SqlServerExtension.csproj \
         --configuration Release \
-        --output ${{ inputs.platform-short }}/Extensions \
+        --output ${{ inputs.runtime }}/Extensions \
         --self-contained false \
         --runtime ${{ inputs.runtime }} \
         -p:PublishSingleFile=false \
@@ -112,7 +112,7 @@ runs:
         dotnet publish \
         Extensions/Parquet/Cosmos.DataTransfer.ParquetExtension/Cosmos.DataTransfer.ParquetExtension.csproj \
         --configuration Release \
-        --output ${{ inputs.platform-short }}/Extensions \
+        --output ${{ inputs.runtime }}/Extensions \
         --self-contained false \
         --runtime ${{ inputs.runtime }} \
         -p:PublishSingleFile=false \
@@ -127,7 +127,7 @@ runs:
         dotnet publish \
         Extensions/CognitiveSearch/Cosmos.DataTransfer.CognitiveSearchExtension/Cosmos.DataTransfer.CognitiveSearchExtension.csproj \
         --configuration Release \
-        --output ${{ inputs.platform-short }}/Extensions \
+        --output ${{ inputs.runtime }}/Extensions \
         --self-contained false \
         --runtime ${{ inputs.runtime }} \
         -p:PublishSingleFile=false \
@@ -142,7 +142,7 @@ runs:
         dotnet publish \
         Extensions/Csv/Cosmos.DataTransfer.CsvExtension/Cosmos.DataTransfer.CsvExtension.csproj \
         --configuration Release \
-        --output ${{ inputs.platform-short }}/Extensions \
+        --output ${{ inputs.runtime }}/Extensions \
         --self-contained false \
         --runtime ${{ inputs.runtime }} \
         -p:PublishSingleFile=false \
@@ -157,7 +157,7 @@ runs:
         dotnet publish \
         Extensions/PostgreSQL/Cosmos.DataTransfer.PostgresqlExtension.csproj \
         --configuration Release \
-        --output ${{ inputs.platform-short }}/Extensions \
+        --output ${{ inputs.runtime }}/Extensions \
         --self-contained false \
         --runtime ${{ inputs.runtime }} \
         -p:PublishSingleFile=false \
@@ -170,4 +170,4 @@ runs:
       uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.platform }}-package
-        path: ${{ inputs.platform-short }}/
+        path: ${{ inputs.runtime }}/

--- a/.github/workflows/internal-test-build.yml
+++ b/.github/workflows/internal-test-build.yml
@@ -10,32 +10,41 @@ jobs:
     name: Build self-contained executables
     runs-on: ubuntu-latest
     container: mcr.microsoft.com/dotnet/sdk:8.0
+    strategy:
+      matrix:
+        platform: [windows, mac, linux]
+        runtime: [win-x64, win-arm64, osx-x64, osx-arm64, linux-x64, linux-arm64]
+        include:
+          - platform: windows
+            platform-short: win
+            runtime: win-x64
+          - platform: windows
+            platform-short: win
+            runtime: win-arm64
+          - platform: mac
+            platform-short: mac
+            runtime: osx-x64
+          - platform: mac
+            platform-short: mac
+            runtime: osx-arm64
+          - platform: linux
+            platform-short: linux
+            runtime: linux-x64
+          - platform: linux
+            platform-short: linux
+            runtime: linux-arm64
     steps:
       - name: Check .NET version
         run: dotnet --version
       - name: Checkout source code
         uses: actions/checkout@v3
-      - name: Execute Action build-with-plugins for Windows
+      - name: Execute Action build-with-plugins
         uses: ./.github/actions/build-with-plugins
-        id: build-with-plugins-win
         with:
-          platform: windows
-          platform-short: win
-          runtime: win-x64
+          platform: ${{ matrix.platform }}
+          platform-short: ${{ matrix.platform-short }}
+          runtime: ${{ matrix.runtime }}
           build-version: 0.0.${{ github.run_number }}
-      - name: Execute Action build-with-plugins for MacOS
-        uses: ./.github/actions/build-with-plugins
-        id: build-with-plugins-mac
-        with:
-          platform: mac
-          platform-short: mac
-          runtime: osx-x64
-          build-version: 0.0.${{ github.run_number }}
-      - name: Execute Action build-with-plugins for Linux
-        uses: ./.github/actions/build-with-plugins
-        id: build-with-plugins-linux
-        with:
-          platform: linux
-          platform-short: linux
-          runtime: linux-x64
-          build-version: 0.0.${{ github.run_number }}
+        env:
+          PLATFORM: ${{ matrix.platform }}
+          RUNTIME: ${{ matrix.runtime }}

--- a/.github/workflows/internal-test-build.yml
+++ b/.github/workflows/internal-test-build.yml
@@ -12,8 +12,6 @@ jobs:
     container: mcr.microsoft.com/dotnet/sdk:8.0
     strategy:
       matrix:
-        platform: [windows, mac, linux]
-        runtime: [win-x64, win-arm64, osx-x64, osx-arm64, linux-x64, linux-arm64]
         include:
           - platform: windows
             platform-short: win

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,71 +6,109 @@ on:
         description: 'Version number to build and release'
         required: true
 jobs:
+  build-package:
+    name: Build self-contained executables
+    runs-on: ubuntu-latest
+    container: mcr.microsoft.com/dotnet/sdk:8.0
+    strategy:
+      matrix:
+        include:
+          - platform: windows
+            platform-short: win
+            runtime: win-x64
+          - platform: windows
+            platform-short: win
+            runtime: win-arm64
+          - platform: mac
+            platform-short: mac
+            runtime: osx-x64
+          - platform: mac
+            platform-short: mac
+            runtime: osx-arm64
+          - platform: linux
+            platform-short: linux
+            runtime: linux-x64
+          - platform: linux
+            platform-short: linux
+            runtime: linux-arm64
+    steps:
+      - name: Check .NET version
+        run: dotnet --version
+      - name: Checkout source code
+        uses: actions/checkout@v3
+      - name: Execute Action build-with-plugins
+        uses: ./.github/actions/build-with-plugins
+        with:
+          platform: ${{ matrix.platform }}
+          platform-short: ${{ matrix.platform-short }}
+          runtime: ${{ matrix.runtime }}
+          build-version: ${{ inputs.release-tag }}
+
   github-release:
     name: Create GitHub release
     runs-on: ubuntu-latest
     needs: build-package
     permissions:
       contents: write
+    strategy:
+      matrix:
+        include:
+          - platform: windows
+            platform-short: win
+            runtime: win-x64
+          - platform: windows
+            platform-short: win
+            runtime: win-arm64
+          - platform: mac
+            platform-short: mac
+            runtime: osx-x64
+          - platform: mac
+            platform-short: mac
+            runtime: osx-arm64
+          - platform: linux
+            platform-short: linux
+            runtime: linux-x64
+          - platform: linux
+            platform-short: linux
+            runtime: linux-arm64
     steps:
-      - name: Download Windows x64 package
+      - name: Download package
         uses: actions/download-artifact@v4
         with:
-          name: windows-package
-          path: windows-package
-      - name: Download macOS x64 package
-        uses: actions/download-artifact@v4
-        with:
-          name: mac-package
-          path: mac-package
-      - name: Download Linux x64 package
-        uses: actions/download-artifact@v4
-        with:
-          name: linux-package
-          path: linux-package
+          name: ${{ matrix.runtime }}
+          path: ${{ matrix.runtime }}
+      - name: Extract Linux package
+        if: matrix.platform == 'linux'
+        run: |
+          tar -xzf dmt-${{ matrix.runtime }}.tar.gz -C ${{ matrix.runtime }} .
       - name: Package output files
         run: |
-          zip -r dmt-${{ inputs.release-tag }}-win-x64.zip windows-package/*
-          zip -r dmt-${{ inputs.release-tag }}-mac-x64.zip mac-package/*
-          zip -r dmt-${{ inputs.release-tag }}-linux-x64.zip linux-package/*
+          zip -r dmt-${{ matrix.runtime }} ${{ matrix.runtime }}/*
       - name: Create GitHub release
+        if: matrix.platform == 'windows'
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ inputs.release-tag }}
           files: |
-            dmt-${{ inputs.release-tag }}-win-x64.zip
+            dmt-${{ inputs.release-tag }}-${{ matrix.runtime }}.zip
+      - name: Create GitHub release
+        if: matrix.platform == 'mac' && matrix.runtime == 'osx-x64'
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ inputs.release-tag }}
+          files: |
             dmt-${{ inputs.release-tag }}-mac-x64.zip
-            dmt-${{ inputs.release-tag }}-linux-x64.zip
-  build-package:
-    name: Build self-contained executables
-    runs-on: ubuntu-latest
-    container: mcr.microsoft.com/dotnet/sdk:8.0
-    steps:
-      - name: Check .NET version
-        run: dotnet --version
-      - name: Checkout source code
-        uses: actions/checkout@v3
-      - name: Execute Action build-with-plugins for Windows
-        uses: ./.github/actions/build-with-plugins
-        id: build-with-plugins-win
+      - name: Create GitHub release
+        if: matrix.platform == 'mac' && matrix.runtime == 'osx-arm64'
+        uses: softprops/action-gh-release@v1
         with:
-          platform: windows
-          platform-short: win
-          runtime: win-x64
-          build-version: ${{ inputs.release-tag }}
-      - name: Execute Action build-with-plugins for MacOS
-        uses: ./.github/actions/build-with-plugins
-        id: build-with-plugins-mac
+          tag_name: ${{ inputs.release-tag }}
+          files: |
+            dmt-${{ inputs.release-tag }}-mac-arm64.zip
+      - name: Create GitHub release
+        if: matrix.platform == 'linux'
+        uses: softprops/action-gh-release@v1
         with:
-          platform: mac
-          platform-short: mac
-          runtime: osx-x64
-          build-version: ${{ inputs.release-tag }}
-      - name: Execute Action build-with-plugins for Linux
-        uses: ./.github/actions/build-with-plugins
-        id: build-with-plugins-linux
-        with:
-          platform: linux
-          platform-short: linux
-          runtime: linux-x64
-          build-version: ${{ inputs.release-tag }}
+          tag_name: ${{ inputs.release-tag }}
+          files: |
+            dmt-${{ inputs.release-tag }}.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         run: dotnet --version
       - name: Checkout source code
         uses: actions/checkout@v3
-      - name: Execute Action build-with-plugins
+      - name: Execute Action build-with-plugins ${{ matrix.runtime }}
         uses: ./.github/actions/build-with-plugins
         with:
           platform: ${{ matrix.platform }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Download package
         uses: actions/download-artifact@v4
         with:
-          name: ${{ matrix.runtime }}
+          name: ${{ matrix.runtime }}-package
           path: ${{ matrix.runtime }}
       - name: Extract Linux package
         if: matrix.platform == 'linux'
@@ -104,7 +104,7 @@ jobs:
         with:
           tag_name: ${{ inputs.release-tag }}
           files: |
-            dmt-${{ inputs.release-tag }}-mac-arm64.zip
+            dmt-${{ inputs.release-tag }}-mac-x64.zip
       - name: Create GitHub release
         if: matrix.platform == 'linux'
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,11 +63,11 @@ jobs:
             
             # rename from osx to mac to retain previous naming convention
             mv osx-x64-package mac-x64-package
-            zip -r dmt-${{ inputs.release-tag }}-mac-x64.zip osx-x64-package/*
+            zip -r dmt-${{ inputs.release-tag }}-mac-x64.zip mac-x64-package/*
             
             # rename from osx to mac to retain previous naming convention
             mv osx-arm64-package mac-arm64-package
-            zip -r dmt-${{ inputs.release-tag }}-mac-arm64.zip osx-arm64-package/*
+            zip -r dmt-${{ inputs.release-tag }}-mac-arm64.zip mac-arm64-package/*
 
             # create linux packages using tar as supposed to zip. tar is more common for linux packages
             tar -czvf dmt-${{ inputs.release-tag }}-linux-x64.tar.gz linux-x64-package/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,27 +17,21 @@ jobs:
           - platform: windows
             platform-short: win
             runtime: win-x64
-            artifact-name: dmt-${{ inputs.release-tag }}-win-x64.zip
           - platform: windows
             platform-short: win
             runtime: win-arm64
-            artifact-name: dmt-${{ inputs.release-tag }}-win-arm64.zip
           - platform: mac
             platform-short: mac
             runtime: osx-x64
-            artifact-name: dmt-${{ inputs.release-tag }}-macOS-x64.zip
           - platform: mac
             platform-short: mac
             runtime: osx-arm64
-            artifact-name: dmt-${{ inputs.release-tag }}-macOS-arm64.zip
           - platform: linux
             platform-short: linux
             runtime: linux-x64
-            artifact-name: dmt-${{ inputs.release-tag }}-linux-x64.tar.gz
           - platform: linux
             platform-short: linux
             runtime: linux-arm64
-            artifact-name: dmt-${{ inputs.release-tag }}-linux-arm64.tar.gz
     steps:
       - name: Check .NET version
         run: dotnet --version
@@ -50,19 +44,6 @@ jobs:
           platform-short: ${{ matrix.platform-short }}
           runtime: ${{ matrix.runtime }}
           build-version: ${{ inputs.release-tag }}
-      - name: Package output files
-        run: |
-          if [ "${{ matrix.platform }}" = "linux" ]; then
-            tar -czvf ${{ matrix.artifact-name }} -C ${{ matrix.runtime }}/ .
-          else
-            zip -r ${{ matrix.artifact-name }} ${{ matrix.runtime }}/*
-          fi
-      - name: Upload package
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ matrix.runtime }}-package
-          path: |
-            ${{ matrix.artifact-name }}
 
   create-release:
     name: Create GitHub release
@@ -75,6 +56,14 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: .
+      - name: Package output files
+        run: |
+            zip -r dmt-${{ inputs.release-tag }}-win-x64.zip win-x64-package/*
+            zip -r dmt-${{ inputs.release-tag }}-win-arm64.zip win-arm64-package/*
+            zip -r dmt-${{ inputs.release-tag }}-mac-x64.zip osx-x64-package/*
+            zip -r dmt-${{ inputs.release-tag }}-mac-arm64.zip osx-arm64-package/*
+            zip -r dmt-${{ inputs.release-tag }}-linux-x64.zip linux-x64-package/*
+            zip -r dmt-${{ inputs.release-tag }}-linux-arm64.zip linux-arm64-package/*
       - name: Create GitHub release
         uses: softprops/action-gh-release@v1
         with:
@@ -82,7 +71,7 @@ jobs:
           files: |
             dmt-${{ inputs.release-tag }}-win-x64.zip
             dmt-${{ inputs.release-tag }}-win-arm64.zip
-            dmt-${{ inputs.release-tag }}-macOS-x64.zip
-            dmt-${{ inputs.release-tag }}-macOS-arm64.zip
-            dmt-${{ inputs.release-tag }}-linux-x64.tar.gz
-            dmt-${{ inputs.release-tag }}-linux-arm64.tar.gz
+            dmt-${{ inputs.release-tag }}-mac-x64.zip
+            dmt-${{ inputs.release-tag }}-mac-arm64.zip
+            dmt-${{ inputs.release-tag }}-linux-x64.zip
+            dmt-${{ inputs.release-tag }}-linux-arm64.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,74 +50,40 @@ jobs:
     needs: build-package
     permissions:
       contents: write
-    strategy:
-      matrix:
-        include:
-          - platform: windows
-            platform-short: win
-            runtime: win-x64
-          - platform: windows
-            platform-short: win
-            runtime: win-arm64
-          - platform: mac
-            platform-short: mac
-            runtime: osx-x64
-          - platform: mac
-            platform-short: mac
-            runtime: osx-arm64
-          - platform: linux
-            platform-short: linux
-            runtime: linux-x64
-          - platform: linux
-            platform-short: linux
-            runtime: linux-arm64
     steps:
       - name: Download package
         uses: actions/download-artifact@v4
         with:
           name: ${{ matrix.runtime }}-package
           path: ${{ matrix.runtime }}
-      - name: Package output files ${{ matrix.runtime }}
-        if: matrix.platform == 'linux'
+      - name: Package output files
         run: |
-          tar -czvf dmt-${{ inputs.release-tag }}-${{ matrix.runtime }}.tar.gz -C ${{ matrix.runtime }}/ .
-      - name: Package output files ${{ matrix.runtime }}
-        if: matrix.platform == 'windows'
-        run: |
-          zip -r dmt-${{ inputs.release-tag }}-${{ matrix.runtime }}.zip ${{ matrix.runtime }}/*
-      - name: Package output files ${{ matrix.runtime }}
-        if: matrix.platform == 'mac' && matrix.runtime == 'osx-x64'
-        run: |
-          zip -r dmt-${{ inputs.release-tag }}-mac-x64.zip ${{ matrix.runtime }}/*
-      - name: Package output files ${{ matrix.runtime }}
-        if: matrix.platform == 'mac' && matrix.runtime == 'osx-arm64'
-        run: |
-          zip -r dmt-${{ inputs.release-tag }}-mac-arm64.zip ${{ matrix.runtime }}/*
-      - name: Create GitHub release ${{ matrix.runtime }}
-        if: matrix.platform == 'windows'
-        uses: softprops/action-gh-release@v1
+          if [[ "${{ matrix.platform }}" == "linux" ]]; then
+            tar -czvf dmt-${{ inputs.release-tag }}-${{ matrix.runtime }}.tar.gz -C ${{ matrix.runtime }}/ .
+          elif [[ "${{ matrix.platform }}" == "mac" && "${{ matrix.runtime }}" == "osx-x64" ]]; then
+            zip -r dmt-${{ inputs.release-tag }}-mac-x64.zip ${{ matrix.runtime }}/*
+          elif [[ "${{ matrix.platform }}" == "mac" && "${{ matrix.runtime }}" == "osx-arm64" ]]; then
+            zip -r dmt-${{ inputs.release-tag }}-mac-arm64.zip ${{ matrix.runtime }}/*
+          else
+            zip -r dmt-${{ inputs.release-tag }}-${{ matrix.runtime }}.zip ${{ matrix.runtime }}/*
+      - name: Upload package
+        uses: actions/upload-artifact@v4
         with:
-          tag_name: ${{ inputs.release-tag }}
-          files: |
-            dmt-${{ inputs.release-tag }}-${{ matrix.runtime }}.zip
-      - name: Create GitHub release ${{ matrix.runtime }}
-        if: matrix.platform == 'mac' && matrix.runtime == 'osx-x64'
-        uses: softprops/action-gh-release@v1
-        with:
-          tag_name: ${{ inputs.release-tag }}
-          files: |
-            dmt-${{ inputs.release-tag }}-mac-x64.zip
-      - name: Create GitHub release ${{ matrix.runtime }}
-        if: matrix.platform == 'mac' && matrix.runtime == 'osx-arm64'
-        uses: softprops/action-gh-release@v1
-        with:
-          tag_name: ${{ inputs.release-tag }}
-          files: |
-            dmt-${{ inputs.release-tag }}-mac-arm64.zip
-      - name: Create GitHub release ${{ matrix.runtime }}
-        if: matrix.platform == 'linux'
-        uses: softprops/action-gh-release@v1
-        with:
-          tag_name: ${{ inputs.release-tag }}
-          files: |
+          name: ${{ matrix.runtime }}-package
+          path: |
             dmt-${{ inputs.release-tag }}-${{ matrix.runtime }}.tar.gz
+            dmt-${{ inputs.release-tag }}-mac-x64.zip
+            dmt-${{ inputs.release-tag }}-mac-arm64.zip
+            dmt-${{ inputs.release-tag }}-${{ matrix.runtime }}.zip
+      - name: Create GitHub release
+        if: always()
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ inputs.release-tag }}
+          files: |
+            dmt-${{ inputs.release-tag }}-win-x64.zip
+            dmt-${{ inputs.release-tag }}-win-arm64.zip
+            dmt-${{ inputs.release-tag }}-mac-x64.zip
+            dmt-${{ inputs.release-tag }}-mac-arm64.zip
+            dmt-${{ inputs.release-tag }}-linux-x64.tar.gz
+            dmt-${{ inputs.release-tag }}-linux-arm64.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,27 @@ jobs:
     needs: build-package
     permissions:
       contents: write
+    strategy:
+      matrix:
+        include:
+          - platform: windows
+            platform-short: win
+            runtime: win-x64
+          - platform: windows
+            platform-short: win
+            runtime: win-arm64
+          - platform: mac
+            platform-short: mac
+            runtime: osx-x64
+          - platform: mac
+            platform-short: mac
+            runtime: osx-arm64
+          - platform: linux
+            platform-short: linux
+            runtime: linux-x64
+          - platform: linux
+            platform-short: linux
+            runtime: linux-arm64
     steps:
       - name: Download package
         uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,15 +84,15 @@ jobs:
       - name: Package output files ${{ matrix.runtime }}
         if: matrix.platform == 'windows'
         run: |
-          zip -r dmt-${{ inputs.release-tag }}-${{ matrix.runtime }} ${{ matrix.runtime }}/*
+          zip -r dmt-${{ inputs.release-tag }}-${{ matrix.runtime }}.zip ${{ matrix.runtime }}/*
       - name: Package output files ${{ matrix.runtime }}
         if: matrix.platform == 'mac' && matrix.runtime == 'osx-x64'
         run: |
-          zip -r dmt-${{ inputs.release-tag }}-mac-x64 ${{ matrix.runtime }}/*
+          zip -r dmt-${{ inputs.release-tag }}-mac-x64.zip ${{ matrix.runtime }}/*
       - name: Package output files ${{ matrix.runtime }}
         if: matrix.platform == 'mac' && matrix.runtime == 'osx-arm64'
         run: |
-          zip -r dmt-${{ inputs.release-tag }}-mac-arm64 ${{ matrix.runtime }}/*
+          zip -r dmt-${{ inputs.release-tag }}-mac-arm64.zip ${{ matrix.runtime }}/*
       - name: Create GitHub release ${{ matrix.runtime }}
         if: matrix.platform == 'windows'
         uses: softprops/action-gh-release@v1
@@ -113,7 +113,7 @@ jobs:
         with:
           tag_name: ${{ inputs.release-tag }}
           files: |
-            dmt-${{ inputs.release-tag }}-mac-x64.zip
+            dmt-${{ inputs.release-tag }}-mac-arm64.zip
       - name: Create GitHub release ${{ matrix.runtime }}
         if: matrix.platform == 'linux'
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,8 +62,8 @@ jobs:
             zip -r dmt-${{ inputs.release-tag }}-win-arm64.zip win-arm64-package/*
             zip -r dmt-${{ inputs.release-tag }}-mac-x64.zip osx-x64-package/*
             zip -r dmt-${{ inputs.release-tag }}-mac-arm64.zip osx-arm64-package/*
-            zip -r dmt-${{ inputs.release-tag }}-linux-x64.zip linux-x64-package/*
-            zip -r dmt-${{ inputs.release-tag }}-linux-arm64.zip linux-arm64-package/*
+            tar -czvf dmt-${{ inputs.release-tag }}-linux-x64.tar.gz linux-x64-package/*
+            tar -czvf dmt-${{ inputs.release-tag }}-linux-arm64.tar.gz linux-arm64-package/*
       - name: Create GitHub release
         uses: softprops/action-gh-release@v1
         with:
@@ -73,5 +73,5 @@ jobs:
             dmt-${{ inputs.release-tag }}-win-arm64.zip
             dmt-${{ inputs.release-tag }}-mac-x64.zip
             dmt-${{ inputs.release-tag }}-mac-arm64.zip
-            dmt-${{ inputs.release-tag }}-linux-x64.zip
-            dmt-${{ inputs.release-tag }}-linux-arm64.zip
+            dmt-${{ inputs.release-tag }}-linux-x64.tar.gz
+            dmt-${{ inputs.release-tag }}-linux-arm64.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,38 +77,47 @@ jobs:
         with:
           name: ${{ matrix.runtime }}-package
           path: ${{ matrix.runtime }}
-      - name: Extract Linux package
+      - name: Package output files ${{ matrix.runtime }}
         if: matrix.platform == 'linux'
         run: |
-          tar -xzf dmt-${{ matrix.runtime }}.tar.gz -C ${{ matrix.runtime }} .
-      - name: Package output files
+          tar -czvf dmt-${{ inputs.release-tag }}-${{ matrix.runtime }}.tar.gz -C ${{ matrix.runtime }}/ .
+      - name: Package output files ${{ matrix.runtime }}
+        if: matrix.platform == 'windows'
         run: |
-          zip -r dmt-${{ matrix.runtime }} ${{ matrix.runtime }}/*
-      - name: Create GitHub release
+          zip -r dmt-${{ inputs.release-tag }}-${{ matrix.runtime }} ${{ matrix.runtime }}/*
+      - name: Package output files ${{ matrix.runtime }}
+        if: matrix.platform == 'mac' && matrix.runtime == 'osx-x64'
+        run: |
+          zip -r dmt-${{ inputs.release-tag }}-mac-x64 ${{ matrix.runtime }}/*
+      - name: Package output files ${{ matrix.runtime }}
+        if: matrix.platform == 'mac' && matrix.runtime == 'osx-arm64'
+        run: |
+          zip -r dmt-${{ inputs.release-tag }}-mac-arm64 ${{ matrix.runtime }}/*
+      - name: Create GitHub release ${{ matrix.runtime }}
         if: matrix.platform == 'windows'
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ inputs.release-tag }}
           files: |
             dmt-${{ inputs.release-tag }}-${{ matrix.runtime }}.zip
-      - name: Create GitHub release
+      - name: Create GitHub release ${{ matrix.runtime }}
         if: matrix.platform == 'mac' && matrix.runtime == 'osx-x64'
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ inputs.release-tag }}
           files: |
             dmt-${{ inputs.release-tag }}-mac-x64.zip
-      - name: Create GitHub release
+      - name: Create GitHub release ${{ matrix.runtime }}
         if: matrix.platform == 'mac' && matrix.runtime == 'osx-arm64'
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ inputs.release-tag }}
           files: |
             dmt-${{ inputs.release-tag }}-mac-x64.zip
-      - name: Create GitHub release
+      - name: Create GitHub release ${{ matrix.runtime }}
         if: matrix.platform == 'linux'
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ inputs.release-tag }}
           files: |
-            dmt-${{ inputs.release-tag }}.tar.gz
+            dmt-${{ inputs.release-tag }}-${{ matrix.runtime }}.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
       release-tag:
         description: 'Version number to build and release'
         required: true
+
 jobs:
   build-package:
     name: Build self-contained executables
@@ -16,21 +17,27 @@ jobs:
           - platform: windows
             platform-short: win
             runtime: win-x64
+            artifact-name: dmt-${{ inputs.release-tag }}-win-x64.zip
           - platform: windows
             platform-short: win
             runtime: win-arm64
+            artifact-name: dmt-${{ inputs.release-tag }}-win-arm64.zip
           - platform: mac
             platform-short: mac
             runtime: osx-x64
+            artifact-name: dmt-${{ inputs.release-tag }}-macOS-x64.zip
           - platform: mac
             platform-short: mac
             runtime: osx-arm64
+            artifact-name: dmt-${{ inputs.release-tag }}-macOS-arm64.zip
           - platform: linux
             platform-short: linux
             runtime: linux-x64
+            artifact-name: dmt-${{ inputs.release-tag }}-linux-x64.tar.gz
           - platform: linux
             platform-short: linux
             runtime: linux-arm64
+            artifact-name: dmt-${{ inputs.release-tag }}-linux-arm64.tar.gz
     steps:
       - name: Check .NET version
         run: dotnet --version
@@ -43,68 +50,39 @@ jobs:
           platform-short: ${{ matrix.platform-short }}
           runtime: ${{ matrix.runtime }}
           build-version: ${{ inputs.release-tag }}
-
-  github-release:
-    name: Create GitHub release
-    runs-on: ubuntu-latest
-    needs: build-package
-    permissions:
-      contents: write
-    strategy:
-      matrix:
-        include:
-          - platform: windows
-            platform-short: win
-            runtime: win-x64
-          - platform: windows
-            platform-short: win
-            runtime: win-arm64
-          - platform: mac
-            platform-short: mac
-            runtime: osx-x64
-          - platform: mac
-            platform-short: mac
-            runtime: osx-arm64
-          - platform: linux
-            platform-short: linux
-            runtime: linux-x64
-          - platform: linux
-            platform-short: linux
-            runtime: linux-arm64
-    steps:
-      - name: Download package
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ matrix.runtime }}-package
-          path: ${{ matrix.runtime }}
       - name: Package output files
         run: |
           if [[ "${{ matrix.platform }}" == "linux" ]]; then
-            tar -czvf dmt-${{ inputs.release-tag }}-${{ matrix.runtime }}.tar.gz -C ${{ matrix.runtime }}/ .
-          elif [[ "${{ matrix.platform }}" == "mac" && "${{ matrix.runtime }}" == "osx-x64" ]]; then
-            zip -r dmt-${{ inputs.release-tag }}-mac-x64.zip ${{ matrix.runtime }}/*
-          elif [[ "${{ matrix.platform }}" == "mac" && "${{ matrix.runtime }}" == "osx-arm64" ]]; then
-            zip -r dmt-${{ inputs.release-tag }}-mac-arm64.zip ${{ matrix.runtime }}/*
+            tar -czvf ${{ matrix.artifact-name }} -C ${{ matrix.runtime }}/ .
           else
-            zip -r dmt-${{ inputs.release-tag }}-${{ matrix.runtime }}.zip ${{ matrix.runtime }}/*
+            zip -r ${{ matrix.artifact-name }} ${{ matrix.runtime }}/*
+          fi
       - name: Upload package
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.runtime }}-package
           path: |
-            dmt-${{ inputs.release-tag }}-${{ matrix.runtime }}.tar.gz
-            dmt-${{ inputs.release-tag }}-mac-x64.zip
-            dmt-${{ inputs.release-tag }}-mac-arm64.zip
-            dmt-${{ inputs.release-tag }}-${{ matrix.runtime }}.zip
+            ${{ matrix.artifact-name }}
+
+  create-release:
+    name: Create GitHub release
+    runs-on: ubuntu-latest
+    needs: build-package
+    permissions:
+      contents: write
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: .
       - name: Create GitHub release
-        if: always()
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ inputs.release-tag }}
           files: |
             dmt-${{ inputs.release-tag }}-win-x64.zip
             dmt-${{ inputs.release-tag }}-win-arm64.zip
-            dmt-${{ inputs.release-tag }}-mac-x64.zip
-            dmt-${{ inputs.release-tag }}-mac-arm64.zip
+            dmt-${{ inputs.release-tag }}-macOS-x64.zip
+            dmt-${{ inputs.release-tag }}-macOS-arm64.zip
             dmt-${{ inputs.release-tag }}-linux-x64.tar.gz
             dmt-${{ inputs.release-tag }}-linux-arm64.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,8 +60,16 @@ jobs:
         run: |
             zip -r dmt-${{ inputs.release-tag }}-win-x64.zip win-x64-package/*
             zip -r dmt-${{ inputs.release-tag }}-win-arm64.zip win-arm64-package/*
+            
+            # rename from osx to mac to retain previous naming convention
+            mv osx-x64-package mac-x64-package
             zip -r dmt-${{ inputs.release-tag }}-mac-x64.zip osx-x64-package/*
+            
+            # rename from osx to mac to retain previous naming convention
+            mv osx-arm64-package mac-arm64-package
             zip -r dmt-${{ inputs.release-tag }}-mac-arm64.zip osx-arm64-package/*
+
+            # create linux packages using tar as supposed to zip. tar is more common for linux packages
             tar -czvf dmt-${{ inputs.release-tag }}-linux-x64.tar.gz linux-x64-package/*
             tar -czvf dmt-${{ inputs.release-tag }}-linux-arm64.tar.gz linux-arm64-package/*
       - name: Create GitHub release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           # for linux, use tar to create a compressed archive
           # for macOS and Windows, use zip to create a compressed archive
-          if [ "${{ matrix.platform }}" == "linux" ]; then
+          if [ "${{ matrix.platform }}" = "linux" ]; then
             tar -czvf ${{ matrix.artifact-name }} -C ${{ matrix.runtime }}/ .
           else
             zip -r ${{ matrix.artifact-name }} ${{ matrix.runtime }}/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
             # create linux packages using tar as supposed to zip. tar is more common for linux packages
             tar -czvf dmt-${{ inputs.release-tag }}-linux-x64.tar.gz linux-x64-package/*
             tar -czvf dmt-${{ inputs.release-tag }}-linux-arm64.tar.gz linux-arm64-package/*
-      - name: Create GitHub release
+      - name: Create GitHub release ${{ inputs.release-tag }}
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ inputs.release-tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,9 @@ jobs:
           build-version: ${{ inputs.release-tag }}
       - name: Package output files
         run: |
-          if [[ "${{ matrix.platform }}" == "linux" ]]; then
+          # for linux, use tar to create a compressed archive
+          # for macOS and Windows, use zip to create a compressed archive
+          if [ "${{ matrix.platform }}" == "linux" ]; then
             tar -czvf ${{ matrix.artifact-name }} -C ${{ matrix.runtime }}/ .
           else
             zip -r ${{ matrix.artifact-name }} ${{ matrix.runtime }}/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,8 +52,6 @@ jobs:
           build-version: ${{ inputs.release-tag }}
       - name: Package output files
         run: |
-          # for linux, use tar to create a compressed archive
-          # for macOS and Windows, use zip to create a compressed archive
           if [ "${{ matrix.platform }}" = "linux" ]; then
             tar -czvf ${{ matrix.artifact-name }} -C ${{ matrix.runtime }}/ .
           else

--- a/README.md
+++ b/README.md
@@ -26,7 +26,10 @@ The Azure Cosmos DB Desktop Data Migration Tool is an open-source project contai
 
 ## Quick Installation
 
-To use the tool, download the latest zip file for your platform (win-x64, mac-x64, or linux-x64) from [Releases](https://github.com/AzureCosmosDB/data-migration-desktop-tool/releases) and extract all files to your desired install location. To begin a data transfer operation, first populate the `migrationsettings.json` file with appropriate settings for your data source and sink (see [detailed instructions](#using-the-command-line) below or [review examples](ExampleConfigs.md)), and then run the application from a command line: `dmt.exe` on Windows or `dmt` on other platforms.
+To use the tool, download the latest archive file for your platform (win-x64, win-arm64, mac-x64, mac-arm64, linux-x64, linux-arm64) from [Releases](https://github.com/AzureCosmosDB/data-migration-desktop-tool/releases) and extract all files to your desired install location. To begin a data transfer operation, first populate the `migrationsettings.json` file with appropriate settings for your data source and sink (see [detailed instructions](#using-the-command-line) below or [review examples](ExampleConfigs.md)), and then run the application from a command line: `dmt.exe` on Windows or `dmt` on other platforms. 
+
+If using RBAC (Role Based Access Control) (migrate-passwordless)[https://learn.microsoft.com/azure/cosmos-db/nosql/migrate-passwordless?tabs=sign-in-azure-cli%2Cdotnet%2Cazure-portal-create%2Cazure-portal-associate%2Capp-service-identity] ensure you are authenticated with Azure see (Troubleshoot Azure Identity authentication issues
+)[https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/TROUBLESHOOTING.md] One common way to authenticate is using the Azure CLI (How to install the Azure CLI)[https://learn.microsoft.com/cli/azure/install-azure-cli] and `az login`
 
 ## Extension documentation
 
@@ -203,6 +206,14 @@ This tutorial outlines how to use the Azure Cosmos DB Desktop Data Migration Too
     ```
 
     > **Note**: Before you run the tool on macOS, you'll need to follow Apple's instructions on how to [Open a Mac app from an unidentified developer](https://support.apple.com/guide/mac-help/open-a-mac-app-from-an-unidentified-developer-mh40616/mac).
+
+    **Using Linux**
+
+    ```bash
+    ./dmt
+    ```
+
+    > **Note**: Use the `--settings` option with a file path to specify a different settings file (overriding the default **migrationsettings.json** file). This facilitates automating running of different migration jobs in a programmatic loop.
 
 ## Creating Extensions
 

--- a/README.md
+++ b/README.md
@@ -28,9 +28,7 @@ The Azure Cosmos DB Desktop Data Migration Tool is an open-source project contai
 
 To use the tool, download the latest archive file for your platform (win-x64, win-arm64, mac-x64, mac-arm64, linux-x64, linux-arm64) from [Releases](https://github.com/AzureCosmosDB/data-migration-desktop-tool/releases) and extract all files to your desired install location. To begin a data transfer operation, first populate the `migrationsettings.json` file with appropriate settings for your data source and sink (see [detailed instructions](#using-the-command-line) below or [review examples](ExampleConfigs.md)), and then run the application from a command line: `dmt.exe` on Windows or `dmt` on other platforms. 
 
-If using RBAC (Role Based Access Control) (migrate-passwordless)[https://learn.microsoft.com/azure/cosmos-db/nosql/migrate-passwordless?tabs=sign-in-azure-cli%2Cdotnet%2Cazure-portal-create%2Cazure-portal-associate%2Capp-service-identity] ensure you are authenticated with Azure see (Troubleshoot Azure Identity authentication issues
-)[https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/TROUBLESHOOTING.md] One common way to authenticate is using the Azure CLI (How to install the Azure CLI)[https://learn.microsoft.com/cli/azure/install-azure-cli] and `az login`
-
+If using RBAC (Role Based Access Control) [migrate-passwordless](https://learn.microsoft.com/azure/cosmos-db/nosql/migrate-passwordless?tabs=sign-in-azure-cli%2Cdotnet%2Cazure-portal-create%2Cazure-portal-associate%2Capp-service-identity) ensure you are authenticated with Azure see [Troubleshoot Azure Identity authentication issues](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/identity/Azure.Identity/TROUBLESHOOTING.md) One common way to authenticate is using the Azure CLI [How to install the Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli) and `az login`
 ## Extension documentation
 
 Multiple extensions are provided in this repository. Find the documentation for the usage and configuration of each using the links provided:


### PR DESCRIPTION
This pull request includes updates to the build and release workflows, as well as improvements to the documentation. The main changes involve refactoring the build configurations to use a matrix strategy, updating the output paths, and enhancing the release process to support multiple platforms and architectures. New ARM64 builds have been added to the release packages.

closes #178 

### Workflow and Build Configuration Updates:

* [`.github/actions/build-with-plugins/action.yml`](diffhunk://#diff-dfe3e6d929c314791f7508bf6d7445cb07e0e58e68ad2863b36ccc1af0a75d20L25-R25): Updated the `dotnet publish` commands to use `${{ inputs.runtime }}` instead of `${{ inputs.platform-short }}` for the output paths. This change ensures consistency in the output directory structure. [[1]](diffhunk://#diff-dfe3e6d929c314791f7508bf6d7445cb07e0e58e68ad2863b36ccc1af0a75d20L25-R25) [[2]](diffhunk://#diff-dfe3e6d929c314791f7508bf6d7445cb07e0e58e68ad2863b36ccc1af0a75d20L40-R40) [[3]](diffhunk://#diff-dfe3e6d929c314791f7508bf6d7445cb07e0e58e68ad2863b36ccc1af0a75d20L55-R55) [[4]](diffhunk://#diff-dfe3e6d929c314791f7508bf6d7445cb07e0e58e68ad2863b36ccc1af0a75d20L70-R70) [[5]](diffhunk://#diff-dfe3e6d929c314791f7508bf6d7445cb07e0e58e68ad2863b36ccc1af0a75d20L85-R85) [[6]](diffhunk://#diff-dfe3e6d929c314791f7508bf6d7445cb07e0e58e68ad2863b36ccc1af0a75d20L100-R100) [[7]](diffhunk://#diff-dfe3e6d929c314791f7508bf6d7445cb07e0e58e68ad2863b36ccc1af0a75d20L115-R115) [[8]](diffhunk://#diff-dfe3e6d929c314791f7508bf6d7445cb07e0e58e68ad2863b36ccc1af0a75d20L130-R130) [[9]](diffhunk://#diff-dfe3e6d929c314791f7508bf6d7445cb07e0e58e68ad2863b36ccc1af0a75d20L145-R145) [[10]](diffhunk://#diff-dfe3e6d929c314791f7508bf6d7445cb07e0e58e68ad2863b36ccc1af0a75d20L160-R160) [[11]](diffhunk://#diff-dfe3e6d929c314791f7508bf6d7445cb07e0e58e68ad2863b36ccc1af0a75d20L172-R173)

* [`.github/workflows/internal-test-build.yml`](diffhunk://#diff-a27a6e3916f9c9a1a350bf49c505c010998bdff4be8d5d27c57d709cc8641beaR13-R48): Introduced a matrix strategy to build self-contained executables for different platforms and architectures, streamlining the build process and reducing redundancy.

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R8-R85): Added a matrix strategy for building packages and updated the release job to handle multiple platforms and architectures. This change simplifies the release process and ensures all necessary packages are created and uploaded.

* Linux release packages have been switched to tarball's vs. zip as tar is a more common package available on Linux distros. 

### Documentation Updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L29-R32): Updated installation instructions to include new platforms and architectures (win-arm64, mac-arm64, linux-arm64) and added guidance for using RBAC and authentication with Azure CLI. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L29-R32) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R210-R217)

### How verified:
1. Ran release action on my own fork: https://github.com/philnach/data-migration-desktop-tool/releases/tag/0.12
2. Verified new native arm64 builds work on native arm64 devices:
![image](https://github.com/user-attachments/assets/885d411c-31e5-4f84-9f74-2f25d72d1997)
