### PR TITLE
Enhance Throughput Validation and Configuration for Cosmos DB Containers

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,7 @@
     <PackageVersion Include="coverlet.collector" Version="6.0.2" />
     <PackageVersion Include="coverlet.msbuild" Version="2.8.0" />
     <PackageVersion Include="CsvHelper" Version="33.0.1" />
-    <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.46.1" />
+    <PackageVersion Include="Microsoft.Azure.Cosmos" Version="3.49.0" />
     <PackageVersion Include="Microsoft.Azure.Cosmos.Encryption" Version="2.0.4" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="6.0.1" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="9.0.1" />

--- a/Extensions/Cosmos/Cosmos.DataTransfer.CosmosExtension/CosmosDataSinkExtension.cs
+++ b/Extensions/Cosmos/Cosmos.DataTransfer.CosmosExtension/CosmosDataSinkExtension.cs
@@ -51,18 +51,18 @@ namespace Cosmos.DataTransfer.CosmosExtension
                         var currentThroughput = throughputResponse.Value;
 
                         // Check if the current throughput matches the desired configuration
-                        if (settings.UseAutoscaleForDatabase && currentThroughput != settings.CreatedContainerMaxThroughput)
+                        if (settings.UseAutoscaleForDatabase && currentThroughput.HasValue && settings.CreatedContainerMaxThroughput.HasValue && currentThroughput != settings.CreatedContainerMaxThroughput)
                         {
                             // Update to autoscaling throughput
                             await database.ReplaceThroughputAsync(
-                                ThroughputProperties.CreateAutoscaleThroughput(settings.CreatedContainerMaxThroughput ?? 4000),
+                                ThroughputProperties.CreateAutoscaleThroughput(settings.CreatedContainerMaxThroughput.Value),
                                 cancellationToken: cancellationToken);
                         }
-                        else if (!settings.UseAutoscaleForDatabase && currentThroughput != settings.CreatedContainerMaxThroughput)
+                        else if (!settings.UseAutoscaleForDatabase && currentThroughput.HasValue && settings.CreatedContainerMaxThroughput.HasValue && currentThroughput != settings.CreatedContainerMaxThroughput)
                         {
                             // Update to manual throughput
                             await database.ReplaceThroughputAsync(
-                                ThroughputProperties.CreateManualThroughput(settings.CreatedContainerMaxThroughput ?? 400),
+                                ThroughputProperties.CreateManualThroughput(settings.CreatedContainerMaxThroughput.Value),
                                 requestOptions: null,
                                 cancellationToken: cancellationToken);
                         }

--- a/Extensions/Cosmos/Cosmos.DataTransfer.CosmosExtension/CosmosDataSinkExtension.cs
+++ b/Extensions/Cosmos/Cosmos.DataTransfer.CosmosExtension/CosmosDataSinkExtension.cs
@@ -31,7 +31,7 @@ namespace Cosmos.DataTransfer.CosmosExtension
             {
                 if (settings.InitClientEncryption)
                 {
-                    container = await client.GetContainer(settings.Database, settings.Container).InitializeEncryptionAsync();
+                    container = await client.GetContainer(settings.Database, settings.Container).InitializeEncryptionAsync(cancellationToken);
                 }
                 else
                 {
@@ -51,14 +51,14 @@ namespace Cosmos.DataTransfer.CosmosExtension
                         var currentThroughput = throughputResponse.Value;
 
                         // Check if the current throughput matches the desired configuration
-                        if (settings.UseAutoscaleForDatabase && currentThroughput.HasValue && settings.CreatedContainerMaxThroughput.HasValue && currentThroughput != settings.CreatedContainerMaxThroughput)
+                        if (settings.UseAutoscaleForDatabase && settings.CreatedContainerMaxThroughput.HasValue && currentThroughput != settings.CreatedContainerMaxThroughput)
                         {
                             // Update to autoscaling throughput
                             await database.ReplaceThroughputAsync(
                                 ThroughputProperties.CreateAutoscaleThroughput(settings.CreatedContainerMaxThroughput.Value),
                                 cancellationToken: cancellationToken);
                         }
-                        else if (!settings.UseAutoscaleForDatabase && currentThroughput.HasValue && settings.CreatedContainerMaxThroughput.HasValue && currentThroughput != settings.CreatedContainerMaxThroughput)
+                        else if (!settings.UseAutoscaleForDatabase && settings.CreatedContainerMaxThroughput.HasValue && currentThroughput != settings.CreatedContainerMaxThroughput)
                         {
                             // Update to manual throughput
                             await database.ReplaceThroughputAsync(

--- a/Extensions/Cosmos/Cosmos.DataTransfer.CosmosExtension/CosmosDataSourceExtension.cs
+++ b/Extensions/Cosmos/Cosmos.DataTransfer.CosmosExtension/CosmosDataSourceExtension.cs
@@ -24,7 +24,7 @@ namespace Cosmos.DataTransfer.CosmosExtension
             
             if(settings.InitClientEncryption)
             {
-                container = await client.GetContainer(settings.Database, settings.Container).InitializeEncryptionAsync();
+                container = await client.GetContainer(settings.Database, settings.Container).InitializeEncryptionAsync(cancellationToken);
             }
             else
             {

--- a/Extensions/Cosmos/Cosmos.DataTransfer.CosmosExtension/CosmosSinkSettings.cs
+++ b/Extensions/Cosmos/Cosmos.DataTransfer.CosmosExtension/CosmosSinkSettings.cs
@@ -66,7 +66,7 @@ namespace Cosmos.DataTransfer.CosmosExtension
 
             if (IsServerlessAccount && (CreatedContainerMaxThroughput.HasValue || UseSharedThroughput))
             {
-                yield return new ValidationResult("Serverless accounts cannot have throughput set", new[] { nameof(CreatedContainerMaxThroughput), nameof(UseSharedThroughput) });
+                yield return new ValidationResult("Serverless accounts cannot have shared throughput", new[] { nameof(CreatedContainerMaxThroughput), nameof(UseSharedThroughput) });
             }
 
             if (PartitionKeyPaths?.Any(p => !string.IsNullOrEmpty(p)) == true)

--- a/Extensions/Cosmos/Cosmos.DataTransfer.CosmosExtension/CosmosSinkSettings.cs
+++ b/Extensions/Cosmos/Cosmos.DataTransfer.CosmosExtension/CosmosSinkSettings.cs
@@ -11,8 +11,20 @@ namespace Cosmos.DataTransfer.CosmosExtension
         public int MaxRetryCount { get; set; } = 5;
         public int InitialRetryDurationMs { get; set; } = 200;
         public int? CreatedContainerMaxThroughput { get; set; }
+
+        /// <summary>
+        /// If true, the database will be created with autoscale enabled otherise it'll be manual.
+        /// </summary>
+        public bool UseAutoscaleForDatabase { get; set; } = false;
+
         public bool UseAutoscaleForCreatedContainer { get; set; } = true;
+
+        /// <summary>
+        /// If true, the database will be created with serverless mode enabled.
+        /// Autoscaling and throughput cannot be set when serverless mode is enabled.
+        /// </summary>
         public bool IsServerlessAccount { get; set; } = false;
+
         public bool UseSharedThroughput { get; set; } = false;
         public bool PreserveMixedCaseIds { get; set; } = false;
         public DataWriteMode WriteMode { get; set; } = DataWriteMode.Insert;

--- a/Extensions/Cosmos/Cosmos.DataTransfer.CosmosExtension/CosmosSinkSettings.cs
+++ b/Extensions/Cosmos/Cosmos.DataTransfer.CosmosExtension/CosmosSinkSettings.cs
@@ -20,6 +20,11 @@ namespace Cosmos.DataTransfer.CosmosExtension
         /// <summary>
         /// If true, the container will be created with autoscale enabled otherwise it'll be manual.
         /// </summary>
+        /// <remarks>
+        /// Conversion from Manual to Autoscale is not supported by the SDK. In order to convert an
+        /// existing container from manual to auto you will need to recreate the container or convert
+        /// the container from the Azure Portal.
+        /// </remarks>
         public bool UseAutoscaleForCreatedContainer { get; set; } = true;
 
         /// <summary>

--- a/Extensions/Cosmos/Cosmos.DataTransfer.CosmosExtension/CosmosSinkSettings.cs
+++ b/Extensions/Cosmos/Cosmos.DataTransfer.CosmosExtension/CosmosSinkSettings.cs
@@ -13,10 +13,13 @@ namespace Cosmos.DataTransfer.CosmosExtension
         public int? CreatedContainerMaxThroughput { get; set; }
 
         /// <summary>
-        /// If true, the database will be created with autoscale enabled otherise it'll be manual.
+        /// If true, the database will be created with autoscale enabled otherwise it'll be manual.
         /// </summary>
         public bool UseAutoscaleForDatabase { get; set; } = false;
 
+        /// <summary>
+        /// If true, the container will be created with autoscale enabled otherwise it'll be manual.
+        /// </summary>
         public bool UseAutoscaleForCreatedContainer { get; set; } = true;
 
         /// <summary>
@@ -25,7 +28,11 @@ namespace Cosmos.DataTransfer.CosmosExtension
         /// </summary>
         public bool IsServerlessAccount { get; set; } = false;
 
+        /// <summary>
+        /// If true, the container will be created with shared throughput enabled.
+        /// </summary>
         public bool UseSharedThroughput { get; set; } = false;
+
         public bool PreserveMixedCaseIds { get; set; } = false;
         public DataWriteMode WriteMode { get; set; } = DataWriteMode.Insert;
         public bool IgnoreNullValues { get; set; } = false;
@@ -50,6 +57,11 @@ namespace Cosmos.DataTransfer.CosmosExtension
                 {
                     yield return new ValidationResult("PartitionKeyPath must be specified when RecreateContainer is true", new[] { nameof(PartitionKeyPath), nameof(PartitionKeyPaths) });
                 }
+            }
+
+            if (IsServerlessAccount && (CreatedContainerMaxThroughput.HasValue || UseSharedThroughput))
+            {
+                yield return new ValidationResult("Serverless accounts cannot have throughput set", new[] { nameof(CreatedContainerMaxThroughput), nameof(UseSharedThroughput) });
             }
 
             if (PartitionKeyPaths?.Any(p => !string.IsNullOrEmpty(p)) == true)

--- a/Extensions/Cosmos/README.md
+++ b/Extensions/Cosmos/README.md
@@ -57,7 +57,42 @@ Or with RBAC:
 }
 ```
 
-Sink requires an additional `PartitionKeyPath` parameter which is used when creating the container if it does not exist. To use hierarchical partition keys, instead use the `PartitionKeyPaths` setting to supply an array of up to 3 paths. It also supports an optional `RecreateContainer` parameter (`false` by default) to delete and then recreate the container to ensure only newly imported data is present. The optional `BatchSize` parameter (100 by default) sets the number of items to accumulate before inserting. `ConnectionMode` can be set to either `Gateway` (default) or `Direct` to control how the client connects to the CosmosDB service. For situations where a container is created as part of the transfer operation `CreatedContainerMaxThroughput` (in RUs) and `UseAutoscaleForCreatedContainer` provide the initial throughput settings which will be in effect when executing the transfer. To instead use shared throughput that has been provisioned at the database level, set the `UseSharedThroughput` parameter to `true`. The optional `WriteMode` parameter specifies the type of data write to use: `InsertStream`, `Insert`, `UpsertStream`, or `Upsert`. The `IsServerlessAccount` parameter specifies whether the target account uses Serverless instead of Provisioned throughput, which affects the way containers are created. Additional parameters allow changing the behavior of the Cosmos client appropriate to your environment. The `PreserveMixedCaseIds` parameter (`false` by default) ignores differently cased `id` fields and writes them through without modification, while generating a separate lowercased `id` field as required by Cosmos. The `IgnoreNullValues` parameter allows for excluding fields with null values when writing to Cosmos DB.
+### Sink Settings
+
+#### **Partition Key Settings**
+- **`PartitionKeyPath`**: Specifies the partition key path when creating the container (e.g., `/id`) if it does not exist.
+- **`PartitionKeyPaths`**: Use this to supply an array of up to 3 paths for hierarchical partition keys.
+
+#### **Database Management**
+- **`UseAutoscaleForDatabase`**: Specifies if the database will be created with autoscale enabled or manual. Defaults to `false`. manual.
+
+#### **Container Management**
+- **`RecreateContainer`**: Optional, defaults to `false`. Deletes and recreates the container to ensure only newly imported data is present.
+- **`CreatedContainerMaxThroughput`**: Specifies the initial throughput (in RUs) for a newly created container.
+- **`UseAutoscaleForCreatedContainer`**: Enables autoscale for the newly created container.
+- **`UseSharedThroughput`**: Set to `true` to use shared throughput provisioned at the database level.
+
+#### **Batching and Write Behavior**
+- **`BatchSize`**: Optional, defaults to `100`. Sets the number of items to accumulate before inserting.
+- **`WriteMode`**: Specifies the type of data write to use. Options:
+  - `InsertStream`
+  - `Insert`
+  - `UpsertStream`
+  - `Upsert`
+
+#### **Connection Settings**
+- **`ConnectionMode`**: Controls how the client connects to the Cosmos DB service. Options:
+  - `Gateway` (default)
+  - `Direct`
+
+#### **Serverless Account**
+- **`IsServerlessAccount`**: Specifies whether the target account uses Serverless instead of Provisioned throughput, which affects the way containers are created.
+  - **Note**: Serverless accounts cannot have shared throughput. See [Azure Cosmos DB serverless account type](https://learn.microsoft.com/azure/cosmos-db/serverless#use-serverless-resources).
+
+#### **Client Behavior**
+- **`PreserveMixedCaseIds`**: Optional, defaults to `false`. Writes `id` fields with their original casing while generating a separate lowercased `id` field as required by Cosmos.
+- **`IgnoreNullValues`**: Optional. Excludes fields with null values when writing to Cosmos DB.
+- **`InitClientEncryption`**: Optional, defaults to `false`. Uses client-side encryption with the container. Can only be used with `UseRbacAuth` set to `true`
 
 ### Sink
 
@@ -73,6 +108,7 @@ Sink requires an additional `PartitionKeyPath` parameter which is used when crea
     "MaxRetryCount": 5,
     "InitialRetryDurationMs": 200,
     "CreatedContainerMaxThroughput": 1000,
+    "UseAutoscaleForDatabase": false,
     "UseAutoscaleForCreatedContainer": true,
     "WriteMode": "InsertStream",
     "PreserveMixedCaseIds": false,


### PR DESCRIPTION
Summary:
This PR introduces enhancements to the CosmosDataSinkExtension to improve the handling of throughput settings for Cosmos DB containers. The changes ensure that container throughput configurations align with database-level settings and provide clear error handling for mismatches. 

**Key updates include:**
1. Added new settings `UseAutoscaleForDatabase` defaulted to false for specifying if the database should use autoscale throughput or manual.
2. Updated the Cosmos DB NuGet to version: 3.49.0 ([changelog](https://github.com/Azure/azure-cosmos-dotnet-v3/blob/master/changelog.md))
3. Added settings validation to indicate Cosmos DB serverless doesn't support autoscaling.
4. Reads and replaces the container throughput if the current throughput doesn't match the desired `CreatedContainerMaxThroughput`
5. Added some documentation to `CosmosSinkSettings`

Testing:
* Verified the changes with both manual and autoscale throughput configurations.
* Tested scenarios where the container needs to be recreated due to mismatched settings.
* Ensured compatibility with serverless accounts and shared throughput modes.

Impact:
* These changes improve the reliability and maintainability of the Cosmos DB integration.
* Users will receive clearer guidance when configuration issues occur, improving the overall developer experience.