### PR TITLE
feat: add azure rbac support on table api

### DIFF
--- a/Extensions/AzureTableAPI/Cosmos.DataTransfer.AzureTableAPIExtension/AzureTableAPIDataSinkExtension.cs
+++ b/Extensions/AzureTableAPI/Cosmos.DataTransfer.AzureTableAPIExtension/AzureTableAPIDataSinkExtension.cs
@@ -23,7 +23,7 @@ namespace Cosmos.DataTransfer.AzureTableAPIExtension
 
             if (settings.UseRbacAuth)
             {
-                logger.LogInformation("Connecting to Storage account {AccountEndpoint} using {UseRbacAuth} with {EnableInteractiveCredentials}'", settings.AccountEndpoint, nameof(AzureTableAPIDataSinkSettings.UseRbacAuth), nameof(AzureTableAPIDataSinkSettings.EnableInteractiveCredentials));
+                logger.LogInformation("Connecting to Storage account {AccountEndpoint} using {UseRbacAuth} with {EnableInteractiveCredentials}", settings.AccountEndpoint, nameof(AzureTableAPIDataSinkSettings.UseRbacAuth), nameof(AzureTableAPIDataSinkSettings.EnableInteractiveCredentials));
 
                 var credential = new DefaultAzureCredential(includeInteractiveCredentials: settings.EnableInteractiveCredentials);
 #pragma warning disable CS8604 // Validate above ensures AccountEndpoint is not null

--- a/Extensions/AzureTableAPI/Cosmos.DataTransfer.AzureTableAPIExtension/AzureTableAPIDataSinkExtension.cs
+++ b/Extensions/AzureTableAPI/Cosmos.DataTransfer.AzureTableAPIExtension/AzureTableAPIDataSinkExtension.cs
@@ -34,7 +34,7 @@ namespace Cosmos.DataTransfer.AzureTableAPIExtension
             }
             else
             {
-                logger.LogInformation("Connecting to Storage account using {ConnectionString}'", nameof(AzureTableAPIDataSinkSettings.ConnectionString));
+                logger.LogInformation("Connecting to Storage account using {ConnectionString}", nameof(AzureTableAPIDataSinkSettings.ConnectionString));
 
                 serviceClient = new TableServiceClient(settings.ConnectionString);
             }

--- a/Extensions/AzureTableAPI/Cosmos.DataTransfer.AzureTableAPIExtension/AzureTableAPIDataSinkExtension.cs
+++ b/Extensions/AzureTableAPI/Cosmos.DataTransfer.AzureTableAPIExtension/AzureTableAPIDataSinkExtension.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel.Composition;
 using Azure.Data.Tables;
+using Azure.Identity;
 using Cosmos.DataTransfer.AzureTableAPIExtension.Data;
 using Cosmos.DataTransfer.AzureTableAPIExtension.Settings;
 using Cosmos.DataTransfer.Interfaces;
@@ -18,7 +19,26 @@ namespace Cosmos.DataTransfer.AzureTableAPIExtension
             var settings = config.Get<AzureTableAPIDataSinkSettings>();
             settings.Validate();
 
-            var serviceClient = new TableServiceClient(settings.ConnectionString);
+            TableServiceClient serviceClient;
+
+            if (settings.UseRbacAuth)
+            {
+                logger.LogInformation("Connecting to Storage account {AccountEndpoint} using {UseRbacAuth} with {EnableInteractiveCredentials}'", settings.AccountEndpoint, nameof(AzureTableAPIDataSinkSettings.UseRbacAuth), nameof(AzureTableAPIDataSinkSettings.EnableInteractiveCredentials));
+
+                var credential = new DefaultAzureCredential(includeInteractiveCredentials: settings.EnableInteractiveCredentials);
+#pragma warning disable CS8604 // Validate above ensures AccountEndpoint is not null
+                var baseUri = new Uri(settings.AccountEndpoint);
+#pragma warning restore CS8604 // Restore warning
+
+                serviceClient = new TableServiceClient(baseUri, credential);
+            }
+            else
+            {
+                logger.LogInformation("Connecting to Storage account using {ConnectionString}'", nameof(AzureTableAPIDataSinkSettings.ConnectionString));
+
+                serviceClient = new TableServiceClient(settings.ConnectionString);
+            }
+
             var tableClient = serviceClient.GetTableClient(settings.Table);
 
             await tableClient.CreateIfNotExistsAsync();

--- a/Extensions/AzureTableAPI/Cosmos.DataTransfer.AzureTableAPIExtension/AzureTableAPIDataSourceExtension.cs
+++ b/Extensions/AzureTableAPI/Cosmos.DataTransfer.AzureTableAPIExtension/AzureTableAPIDataSourceExtension.cs
@@ -25,7 +25,7 @@ namespace Cosmos.DataTransfer.AzureTableAPIExtension
 
             if (settings.UseRbacAuth)
             {
-                logger.LogInformation("Connecting to Storage account {AccountEndpoint} using {UseRbacAuth} with {EnableInteractiveCredentials}'", settings.AccountEndpoint, nameof(AzureTableAPIDataSinkSettings.UseRbacAuth), nameof(AzureTableAPIDataSinkSettings.EnableInteractiveCredentials));
+                logger.LogInformation("Connecting to Storage account {AccountEndpoint} using {UseRbacAuth} with {EnableInteractiveCredentials}'", settings.AccountEndpoint, nameof(AzureTableAPIDataSourceSettings.UseRbacAuth), nameof(AzureTableAPIDataSourceSettings.EnableInteractiveCredentials));
 
                 var credential = new DefaultAzureCredential(includeInteractiveCredentials: settings.EnableInteractiveCredentials);
 #pragma warning disable CS8604 // Validate above ensures AccountEndpoint is not null

--- a/Extensions/AzureTableAPI/Cosmos.DataTransfer.AzureTableAPIExtension/Cosmos.DataTransfer.AzureTableAPIExtension.csproj
+++ b/Extensions/AzureTableAPI/Cosmos.DataTransfer.AzureTableAPIExtension/Cosmos.DataTransfer.AzureTableAPIExtension.csproj
@@ -9,6 +9,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Azure.Data.Tables" />
+    <PackageReference Include="Azure.Identity" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
 		<PackageReference Include="System.ComponentModel.Composition" />
 		<PackageReference Include="System.Text.Json" />

--- a/Extensions/AzureTableAPI/Cosmos.DataTransfer.AzureTableAPIExtension/Settings/AzureTableAPISettingsBase.cs
+++ b/Extensions/AzureTableAPI/Cosmos.DataTransfer.AzureTableAPIExtension/Settings/AzureTableAPISettingsBase.cs
@@ -9,9 +9,14 @@ namespace Cosmos.DataTransfer.AzureTableAPIExtension.Settings
         /// <summary>
         /// The Connection String.
         /// </summary>
-        [Required]
         [SensitiveValue]
         public string? ConnectionString { get; set; }
+
+        public string? AccountEndpoint { get; set; } = null!;
+
+        public bool UseRbacAuth { get; set; }
+
+        public bool EnableInteractiveCredentials { get; set; }
 
         /// <summary>
         /// The Table name.
@@ -28,5 +33,18 @@ namespace Cosmos.DataTransfer.AzureTableAPIExtension.Settings
         /// The field name to translate the PartitionKey from Table Entities to. (Optional)
         /// </summary>
         public string? PartitionKeyFieldName { get; set; }
+
+        public virtual IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+        {
+            if (!UseRbacAuth && string.IsNullOrEmpty(ConnectionString))
+            {
+                yield return new ValidationResult($"{nameof(ConnectionString)} must be specified unless {nameof(UseRbacAuth)} is true", new[] { nameof(ConnectionString) });
+            }
+
+            if (UseRbacAuth && string.IsNullOrEmpty(AccountEndpoint))
+            {
+                yield return new ValidationResult($"{nameof(AccountEndpoint)} must be specified unless {nameof(UseRbacAuth)} is false", new[] { nameof(AccountEndpoint) });
+            }
+        }
     }
 }

--- a/Extensions/AzureTableAPI/README.md
+++ b/Extensions/AzureTableAPI/README.md
@@ -10,7 +10,7 @@ The AzureTableAPI has a couple required and optional settings for configuring th
 
 The following are the required settings that must be defined for using either the data Source or Sink:
 
-- `ConnectionString` - This defines the Table API Connection String used for connecting to and authenticating with the Table API service. For example, this will contain the name of the Azure Storage Account and the Account Key for connecting to the Table API on the service. This is required.
+- `ConnectionString` or `UseRbacAuth` - These define the authentication method used to connect to the Table API. Se further description and examples [here](#authentication-methods). One of these settings is required.
 - `Table` - This defines the name of the Table to connect to on the Table API service. Such as the name of the Azure Storage Table. This is required.
 
 There are also a couple optional settings that can be configured on the AzureTableAPI to help with mapping data between the Source and Sink:
@@ -28,7 +28,30 @@ The following setting is supported for the Source:
 
 - `QueryFilter` - This enables you to specify an OData filter to be applied to the data being retrieved by the AzureTableAPI Source. This is used in cases where only a subset of data from the source Table is needed in the migration. Example usage to query a subset of entities from the source table: `PartitionKey eq 'foo'`.
 
-## Example Source and Sink Settings Usage
+## Authentication Methods
+
+The AzureTableAPI extension supports two authentication methods for connecting to Azure Table API services:
+
+- **Connection String Authentication**: Use the `ConnectionString` property to specify the account connection string, which includes the account name and key.
+- **Azure RBAC (Role Based Access Control) Authentication**: Set `UseRbacAuth` to `true` to use Entra credentials for authentication. When using RBAC, you must also specify the `AccountEndpoint` property (the Table service endpoint URL). Optionally, set `EnableInteractiveCredentials` to `true` to prompt for login if default credentials are not available (for example, when running locally).
+
+> **Note**: To use RBAC authentication, your Azure account must have the appropriate permissions (such as Storage Table Data Contributor) on the storage account. For more information, see [Authorize access to tables using Microsoft Entra ID](https://learn.microsoft.com/en-us/azure/storage/tables/authorize-access-azure-active-directory).
+
+### Example RBAC Settings
+
+```json
+{
+  "UseRbacAuth": true,
+  "AccountEndpoint": "https://<storage-account-name>.table.core.windows.net",
+  "Table": "SourceTable1",
+  "PartitionKeyFieldName": "State",
+  "RowKeyFieldName": "id",
+  "EnableInteractiveCredentials": true,
+  "QueryFilter": "PartitionKey eq 'WI'"
+}
+```
+
+### Example ConnectionString Source and Sink Settings Usage
 
 The following are a couple example `settings.json` files for configuring the AzureTableAPI Source and Sink extensions.
 


### PR DESCRIPTION
Adds Azure RBAC support to the Azure Table API extension similar to what has already been done for Blob Storage and Cosmos.

Closes #183 