### PR TITLE
Table memory

### DIFF
--- a/Extensions/AzureTableAPI/Cosmos.DataTransfer.AzureTableAPIExtension/AzureTableAPIDataSinkExtension.cs
+++ b/Extensions/AzureTableAPI/Cosmos.DataTransfer.AzureTableAPIExtension/AzureTableAPIDataSinkExtension.cs
@@ -49,6 +49,8 @@ namespace Cosmos.DataTransfer.AzureTableAPIExtension
 
             var maxConcurrency = settings.MaxConcurrentEntityWrites ?? 10;
 
+            logger.LogInformation("Writing data to Azure Table Storage with a maximum of {MaxConcurrency} concurrent writes.", maxConcurrency);
+
             var semaphore = new SemaphoreSlim(maxConcurrency);
             var tasks = new List<Task>();
 

--- a/Extensions/AzureTableAPI/Cosmos.DataTransfer.AzureTableAPIExtension/AzureTableAPIDataSinkExtension.cs
+++ b/Extensions/AzureTableAPI/Cosmos.DataTransfer.AzureTableAPIExtension/AzureTableAPIDataSinkExtension.cs
@@ -6,6 +6,7 @@ using Cosmos.DataTransfer.AzureTableAPIExtension.Settings;
 using Cosmos.DataTransfer.Interfaces;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Polly;
 
 namespace Cosmos.DataTransfer.AzureTableAPIExtension
 {

--- a/Extensions/AzureTableAPI/Cosmos.DataTransfer.AzureTableAPIExtension/Cosmos.DataTransfer.AzureTableAPIExtension.csproj
+++ b/Extensions/AzureTableAPI/Cosmos.DataTransfer.AzureTableAPIExtension/Cosmos.DataTransfer.AzureTableAPIExtension.csproj
@@ -9,8 +9,9 @@
 
 	<ItemGroup>
 		<PackageReference Include="Azure.Data.Tables" />
-    <PackageReference Include="Azure.Identity" />
+		<PackageReference Include="Azure.Identity" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+		<PackageReference Include="Polly" />
 		<PackageReference Include="System.ComponentModel.Composition" />
 		<PackageReference Include="System.Text.Json" />
 	</ItemGroup>
@@ -19,16 +20,8 @@
 		<ProjectReference Include="..\..\..\Interfaces\Cosmos.DataTransfer.Interfaces\Cosmos.DataTransfer.Interfaces.csproj" />
 	</ItemGroup>
 
-	<Target Name="PublishToExtensionsFolder"
-					AfterTargets="Build"
-					Condition=" '$(Configuration)' == 'Debug' AND '$(PublishingToExtensionsFolder)' != 'true' ">
-		<MSBuild
-			Projects="$(MSBuildProjectFile)"
-			Targets="Publish"
-			Properties="Configuration=$(Configuration);
-									PublishProfile=PublishToExtensionsFolder;
-									BuildProjectReferences=false;
-									PublishingToExtensionsFolder=true" />
+	<Target Name="PublishToExtensionsFolder" AfterTargets="Build" Condition=" '$(Configuration)' == 'Debug' AND '$(PublishingToExtensionsFolder)' != 'true' ">
+		<MSBuild Projects="$(MSBuildProjectFile)" Targets="Publish" Properties="Configuration=$(Configuration);&#xD;&#xA;									PublishProfile=PublishToExtensionsFolder;&#xD;&#xA;									BuildProjectReferences=false;&#xD;&#xA;									PublishingToExtensionsFolder=true" />
 	</Target>
 
 </Project>

--- a/Extensions/AzureTableAPI/Cosmos.DataTransfer.AzureTableAPIExtension/Cosmos.DataTransfer.AzureTableAPIExtension.csproj
+++ b/Extensions/AzureTableAPI/Cosmos.DataTransfer.AzureTableAPIExtension/Cosmos.DataTransfer.AzureTableAPIExtension.csproj
@@ -21,7 +21,14 @@
 	</ItemGroup>
 
 	<Target Name="PublishToExtensionsFolder" AfterTargets="Build" Condition=" '$(Configuration)' == 'Debug' AND '$(PublishingToExtensionsFolder)' != 'true' ">
-		<MSBuild Projects="$(MSBuildProjectFile)" Targets="Publish" Properties="Configuration=$(Configuration);&#xD;&#xA;									PublishProfile=PublishToExtensionsFolder;&#xD;&#xA;									BuildProjectReferences=false;&#xD;&#xA;									PublishingToExtensionsFolder=true" />
+		<MSBuild Projects="$(MSBuildProjectFile)" Targets="Publish">
+			<Properties>
+				<Configuration>$(Configuration)</Configuration>
+				<PublishProfile>PublishToExtensionsFolder</PublishProfile>
+				<BuildProjectReferences>false</BuildProjectReferences>
+				<PublishingToExtensionsFolder>true</PublishingToExtensionsFolder>
+			</Properties>
+		</MSBuild>
 	</Target>
 
 </Project>

--- a/Extensions/AzureTableAPI/Cosmos.DataTransfer.AzureTableAPIExtension/Cosmos.DataTransfer.AzureTableAPIExtension.csproj
+++ b/Extensions/AzureTableAPI/Cosmos.DataTransfer.AzureTableAPIExtension/Cosmos.DataTransfer.AzureTableAPIExtension.csproj
@@ -21,14 +21,7 @@
 	</ItemGroup>
 
 	<Target Name="PublishToExtensionsFolder" AfterTargets="Build" Condition=" '$(Configuration)' == 'Debug' AND '$(PublishingToExtensionsFolder)' != 'true' ">
-		<MSBuild Projects="$(MSBuildProjectFile)" Targets="Publish">
-			<Properties>
-				<Configuration>$(Configuration)</Configuration>
-				<PublishProfile>PublishToExtensionsFolder</PublishProfile>
-				<BuildProjectReferences>false</BuildProjectReferences>
-				<PublishingToExtensionsFolder>true</PublishingToExtensionsFolder>
-			</Properties>
-		</MSBuild>
+		<MSBuild Projects="$(MSBuildProjectFile)" Targets="Publish" Properties="Configuration=$(Configuration);&#xD;&#xA;									PublishProfile=PublishToExtensionsFolder;&#xD;&#xA;									BuildProjectReferences=false;&#xD;&#xA;									PublishingToExtensionsFolder=true" />
 	</Target>
 
 </Project>

--- a/Extensions/AzureTableAPI/Cosmos.DataTransfer.AzureTableAPIExtension/Settings/AzureTableAPIDataSinkSettings.cs
+++ b/Extensions/AzureTableAPI/Cosmos.DataTransfer.AzureTableAPIExtension/Settings/AzureTableAPIDataSinkSettings.cs
@@ -2,5 +2,10 @@
 {
     public class AzureTableAPIDataSinkSettings : AzureTableAPISettingsBase
     {
+        /// <summary>
+        /// The Maximum number of concurrent entity writes to the Azure Table API.
+        /// This setting is used to control the number of concurrent writes to the Azure Table API.
+        /// </summary>
+        public int? MaxConcurrentEntityWrites { get; set; }
     }
 }

--- a/Extensions/AzureTableAPI/README.md
+++ b/Extensions/AzureTableAPI/README.md
@@ -28,6 +28,14 @@ The following setting is supported for the Source:
 
 - `QueryFilter` - This enables you to specify an OData filter to be applied to the data being retrieved by the AzureTableAPI Source. This is used in cases where only a subset of data from the source Table is needed in the migration. Example usage to query a subset of entities from the source table: `PartitionKey eq 'foo'`.
 
+### Additional Sink Settings
+
+The AzureTableAPI Source extension has an additional setting that can be configured for writing Table entities.
+
+The following setting is supported for the Sink:
+
+- `MaxConcurrentEntityWrites` - The Maximum number of concurrent entity writes to the Azure Table API. This setting is used to control the number of concurrent writes to the Azure Table API.
+
 ## Authentication Methods
 
 The AzureTableAPI extension supports two authentication methods for connecting to Azure Table API services:


### PR DESCRIPTION
# Description
This change addresses memory issues in the Azure Table extension when transferring writing many entities into the Azure Table. This was due to a 1:1 entity to number of Tasks being created for each insertion. This change addresses this by adding a max writes setting to limit the number of entities being written at once in addition improves resiliency to transient failures.

Fixes #132 

# What's Changed
- Added a max writes setting `MaxConcurrentEntityWrites` to limit the number of entities being written at once. Default value is set to 10.
- Added Polly for retry logic to handle transient failures for response codes: `408, 429, 500, 502, 503, 504`.

# How verified
1. Imported sample data set with default 10 settings.
2. Imported sample data set to 1.
3. Imported sample data set to a large number (400).
4. Imported smaple data set with default value 10.

# Memory usage comparison leveraging sample data set:
Before change memory usage:
Importing sample data set memory reaches 67mb and you can see large increase at around 1.1 seconds.
![image](https://github.com/user-attachments/assets/467409d3-192f-4d59-939c-13616c49f93f)

After change memory usage:
Using default 10 concurrent inserts, memory reaches 38mb and no spike.
![image](https://github.com/user-attachments/assets/dbc6901b-7abe-4154-b94a-36a473587c45)
