### PR TITLE
Switch to Microsoft Container Registry public image of dmt

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,20 @@ You can also run the Data Migration Tool as a Docker container, which is useful 
 
 ### Using Pre-built Docker Image
 
-The easiest way to use the container is to pull the pre-built image from Microsoft Container Registry:
+The easiest way to use the container is to pull the pre-built image from Microsoft Container Registry. You can pull a specific version starting with version `3.0.0` and greater or use the `latest` tag to pull the latest version of the container from the registry.  
+
+**Example using a specific version:**
 
 ```bash
 docker pull mcr.microsoft.com/azurecosmosdb/linux/azure-cosmos-dmt:3.0.0
 docker run -v $(pwd)/config:/config -v $(pwd)/data:/data mcr.microsoft.com/azurecosmosdb/linux/azure-cosmos-dmt:3.0.0 run --settings /config/migrationsettings.json
+```
+
+**Example using latest version:**
+
+```bash
+docker pull mcr.microsoft.com/azurecosmosdb/linux/azure-cosmos-dmt:latest
+docker run -v $(pwd)/config:/config -v $(pwd)/data:/data mcr.microsoft.com/azurecosmosdb/linux/azure-cosmos-dmt:latest run --settings /config/migrationsettings.json
 ```
 
 ### Building the Docker Image Locally


### PR DESCRIPTION
This change updates the documentation to point to the Microsoft Container Registry for where to get a Docker container of dmt useful for CI/CD scenarios.

Fixes #191 

Image showing anonymous pull in WSL:
<img width="2329" height="1266" alt="image" src="https://github.com/user-attachments/assets/e36ed27e-39e6-44f7-9520-ec8fd74209f4" />
