### PR TITLE
Revert "Update release workflow name to include release-tag version"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release Binaries ${{ github.event.inputs.release-tag }}
+name: Release desktop binaries
 on: 
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
This reverts commit 28c729e9fb8eeb762ed9095e27ed2a7ce1c98e03.

The release workflow was broken by my commit.  This reverts back to the previous behavior so we can release builds again.  I'll fix this at a later point.